### PR TITLE
Change masks.py to put mask in a group under the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ To export images via the OMERO API:
 
 ```
 # Image will be saved in current directory as 1.zarr
-$ omero zarr Image:1
+$ omero zarr export Image:1
 
 # Specify an output directory
-$ omero zarr Image:1 --output /home/user/zarr_files
+$ omero zarr export Image:1 --output /home/user/zarr_files
 
 # Cache each plane as a numpy file.npy. If connection is lost, and you need
 # to export again, we can use these instead of downloading again
-# omero zarr Image:1 --cache_numpy
+# omero zarr export Image:1 --cache_numpy
 
 ```
 
@@ -39,6 +39,13 @@ To export images via bioformats2raw we use the ```--bf``` flag:
 export MANAGED_REPO=/var/omero/data/ManagedRepository
 export BF2RAW=/opt/tools/bioformats2raw-0.2.0-SNAPSHOT
 
-$ omero zarr 1 --bf --output /home/user/zarr_files
+$ omero zarr export 1 --bf --output /home/user/zarr_files
 Image exported to /home/user/zarr_files/2chZT.lsm
+```
+
+To export masks for an image:
+
+```
+# Creates a group "masks" under zarr_files/1.zarr
+$ omero zarr masks 1 --output /home/user/zarr_files
 ```

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -97,7 +97,7 @@ class ZarrControl(BaseControl):
             default=str(max(MASK_DTYPE_SIZE.keys())),
             choices=[str(s) for s in sorted(MASK_DTYPE_SIZE.keys())],
             help=(
-                "Integer bit size for each mask pixel, use 2 for a binary "
+                "Integer bit size for each mask pixel, use 1 for a binary "
                 "mask, default %(default)s"
             ),
         )

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -87,6 +87,11 @@ class ZarrControl(BaseControl):
             type=ProxyStringType("Image"),
             help="The Image from which to export Masks.",
         )
+        masks.add_argument(
+            "--group-rois",
+            action="store_true",
+            help="Store each ROI in a separate group.",
+        )
 
         export = parser.add(sub, self.export, EXPORT_HELP)
         export.add_argument(

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -13,7 +13,7 @@ from omero.rtypes import rlong
 from omero.model import ImageI
 
 from .raw_pixels import image_to_zarr
-from .masks import image_masks_to_zarr
+from .masks import image_masks_to_zarr, MASK_DTYPE_SIZE
 
 HELP = "Export data in zarr format."
 EXPORT_HELP = "Export an image in zarr format."
@@ -91,6 +91,15 @@ class ZarrControl(BaseControl):
             "--group-rois",
             action="store_true",
             help="Store each ROI in a separate group.",
+        )
+        masks.add_argument(
+            "--mask-bits",
+            default=str(max(MASK_DTYPE_SIZE.keys())),
+            choices=[str(s) for s in sorted(MASK_DTYPE_SIZE.keys())],
+            help=(
+                "Integer bit size for each mask pixel, use 2 for a binary "
+                "mask, default %(default)s"
+            ),
         )
 
         export = parser.add(sub, self.export, EXPORT_HELP)

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -88,9 +88,12 @@ class ZarrControl(BaseControl):
             help="The Image from which to export Masks.",
         )
         masks.add_argument(
-            "--group-rois",
+            "--split-masks",
             action="store_true",
-            help="Store each ROI in a separate group.",
+            help=(
+                "Store each ROI in a separate group, required if masks "
+                "overlap"
+            ),
         )
         masks.add_argument(
             "--mask-bits",

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -46,7 +46,7 @@ def image_masks_to_zarr(image, args):
     dtype = MASK_DTYPE_SIZE[int(args.mask_bits)]
 
     if masks:
-        if args.group_rois:
+        if args.split_masks:
             for (roi_id, roi) in masks.items():
                 _save_masks([roi], image, str(roi_id), dtype)
         else:
@@ -105,7 +105,7 @@ def _save_masks(masks, image, roi_name, dtype):
 
     # Setting za.attrs[] doesn't work, so go via parent
     if "0" in root:
-        image_name = "0"
+        image_name = "../../0"
     else:
         image_name = "omero://{}.zarr".format(image.id)
     out_masks[roi_name].attrs["image"] = {
@@ -192,7 +192,7 @@ def masks_to_labels(
 
     if not labels:
         # TODO: Set np.int size based on number of labels
-        labels = np.zeros(mask_shape, np.int16)
+        labels = np.zeros(mask_shape, np.int64)
 
     for d in "TCZYX":
         if d in ignored_dimensions:

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -153,7 +153,7 @@ def _mask_to_binim_yx(mask):
     return binarray, (t, c, z, y, x, h, w)
 
 
-def _get_indicies(ignored_dimensions, d, d_value, d_size):
+def _get_indices(ignored_dimensions, d, d_value, d_size):
     """
     Figures out which Z/C/T-planes a mask should be copied to
     """
@@ -210,9 +210,9 @@ def masks_to_labels(
         print(count)
         for mask in shapes:
             binim_yx, (t, c, z, y, x, h, w) = _mask_to_binim_yx(mask)
-            for i_t in _get_indicies(ignored_dimensions, "T", t, size_t):
-                for i_c in _get_indicies(ignored_dimensions, "C", c, size_c):
-                    for i_z in _get_indicies(
+            for i_t in _get_indices(ignored_dimensions, "T", t, size_t):
+                for i_c in _get_indices(ignored_dimensions, "C", c, size_c):
+                    for i_z in _get_indices(
                         ignored_dimensions, "Z", z, size_z
                     ):
                         if check_overlaps and np.any(

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -7,8 +7,12 @@ import zarr
 
 def image_masks_to_zarr(image, args):
 
-    size_x = image.getSizeX()
+    size_t = image.getSizeT()
+    size_c = image.getSizeC()
+    size_z = image.getSizeZ()
     size_y = image.getSizeY()
+    size_x = image.getSizeX()
+    image_shape = (size_t, size_c, size_z, size_y, size_x)
 
     conn = image._conn
     roi_service = conn.getRoiService()
@@ -27,49 +31,125 @@ def image_masks_to_zarr(image, args):
     print(f"Found {len(masks)} masks")
 
     if masks:
-        stack = masks_to_zarr(masks, image)
-        name = f"{image.id}_masks.zarr"
-        root = zarr.open_group(name, mode="w")
-        za = root.create(
-            "0",
-            shape=stack.shape,
-            chunks=(1, 1, size_y, size_x),
-            dtype=stack.dtype,
+        name = f"{image.id}.zarr"
+        root = zarr.open(name)
+        if "masks" in root.group_keys():
+            out_masks = root.masks
+        else:
+            out_masks = root.create_group("masks")
+
+        # TODO: Make each ROI a separate group and use Roi.id as name?
+        roi_name = "0"
+        za = out_masks.create_dataset(
+            roi_name,
+            shape=image_shape,
+            chunks=(1, 1, size_z, size_y, size_x),
+            dtype=np.int16,
+            overwrite=True,
         )
+        masks_to_labels(masks, image_shape, check_overlaps=False, labels=za)
+        # Setting za.attrs[] doesn't work, so go via parent
+        if "0" in root:
+            image_name = "0"
+        else:
+            image_name = "omero://{}.zarr".format(image.id)
+        out_masks[roi_name].attrs["image"] = {
+            "array": image_name,
+            "source": {
+                # 'ts': [],
+                # 'cs': [],
+                # 'zs': [],
+                # 'ys': [],
+                # 'xs': [],
+            },
+        }
 
-        za[:, :, :, :] = stack
-
-        print("Created", name)
+        print("Created {}/{}".format(name, roi_name))
     else:
         print("No masks found on Image")
 
 
-def masks_to_zarr(masks, image):
+def mask_to_binim(mask, image_shape):
+    """
+    :param mask MaskI: An OMERO mask
+    :param image_shape 5-tuple: the image dimensions (T, C, Z, Y, X)
+
+    :return: Binary mask with the same dimensions as the image
+             If `T`, `C` or `Z` are not set on the mask the mask is expanded to
+             all planes in that dimension
+
+    TODO: Move to https://github.com/ome/omero-rois/
+    """
+    size_t, size_c, size_z, size_y, size_x = image_shape
+
+    def get_indicies(d, size_d):
+        if d is not None:
+            return [d]
+        return range(size_d)
+
+    # Create an nd-array same size as image
+    binim = np.zeros(image_shape, np.bool)
+    t = unwrap(mask.theT)
+    c = unwrap(mask.theC)
+    z = unwrap(mask.theZ)
+
+    x = int(mask.x.val)
+    y = int(mask.y.val)
+    w = int(mask.width.val)
+    h = int(mask.height.val)
+
+    mask_packed = mask.getBytes()
+    # convert bytearray into something we can use
+    intarray = np.fromstring(mask_packed, dtype=np.uint8)
+    binarray = np.unpackbits(intarray)
+    # truncate and reshape
+    binarray = np.reshape(binarray[: (w * h)], (h, w))
+
+    for i_t in get_indicies(t, size_t):
+        for i_c in get_indicies(c, size_c):
+            for i_z in get_indicies(z, size_z):
+                binim[i_t, i_c, i_z, y : (y + h), x : (x + w)] = binarray
+
+    return binim
+
+
+def masks_to_labels(masks, image_shape, check_overlaps, labels=None):
+    """
+    :param masks [MaskI]: Iterable container of OMERO masks
+    :param image_shape 5-tuple: the image dimensions (T, C, Z, Y, X)
+    :param check_overlaps bool: Whether to check for overlapping masks or not
+    :param labels nd-array: The optional output array, pass this if you have
+           already created the array and want to fill it.
+
+    :return: Label image with the same dimensions as the image
+             If `T`, `C` or `Z` are not set on the mask the labels are expanded
+             to all planes in that dimension
+
+    TODO: Move to https://github.com/ome/omero-rois/
+    """
 
     # Create np nd-array same size as image
-    size_t = image.getSizeT()
-    size_z = image.getSizeZ()
-    size_x = image.getSizeX()
-    size_y = image.getSizeY()
+    if not labels:
+        # TODO: Set np.int size based on number of labels
+        labels = np.zeros(image_shape, np.int16)
+    assert (
+        labels.shape == image_shape
+    ), "labels must have the same shape as the image"
 
-    labels = np.zeros((size_t, size_z, size_y, size_x))
     for count, shapes in enumerate(masks.values()):
         # All shapes same color for each ROI
+        print(count)
         for mask in shapes:
-            t = unwrap(mask.theT) or 0
-            z = unwrap(mask.theZ) or 0
-            x = int(mask.x.val)
-            y = int(mask.y.val)
-            w = int(mask.width.val)
-            h = int(mask.height.val)
-            mask_packed = mask.getBytes()
-            # convert bytearray into something we can use
-            intarray = np.fromstring(mask_packed, dtype=np.uint8)
-            binarray = np.unpackbits(intarray)
-            # truncate and reshape
-            binarray = np.reshape(binarray[: (w * h)], (h, w))
+            binim = mask_to_binim(mask, image_shape)
+            if check_overlaps and np.any(
+                np.logical_and(labels.astype(np.bool), binim)
+            ):
+                raise Exception(
+                    "Mask {} overlaps with existing labels".format(count)
+                )
+
             # ADD to the array, so zeros in our binarray don't wipe out
             # previous masks
-            labels[t, z, y : (y + h), x : (x + w)] += binarray * (count)
+            labels[:] += binim * count
 
     return labels

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -5,6 +5,16 @@ import numpy as np
 import zarr
 
 
+# Mapping of dimension names to axes in the Zarr
+DIMENSION_ORDER = {
+    "T": 0,
+    "C": 1,
+    "Z": 2,
+    "Y": 3,
+    "X": 4,
+}
+
+
 def image_masks_to_zarr(image, args):
 
     size_t = image.getSizeT()
@@ -31,6 +41,23 @@ def image_masks_to_zarr(image, args):
     print(f"Found {len(masks)} masks")
 
     if masks:
+        # Figure out whether we can flatten some dimensions
+        unique_dims = {
+            "T": set(),
+            "C": set(),
+            "Z": set(),
+        }
+        for shapes in masks.values():
+            for mask in shapes:
+                unique_dims["T"].add(unwrap(mask.theT))
+                unique_dims["C"].add(unwrap(mask.theC))
+                unique_dims["Z"].add(unwrap(mask.theZ))
+        ignored_dimensions = set()
+        print(unique_dims)
+        for d in "TCZ":
+            if unique_dims[d] == {None}:
+                ignored_dimensions.add(d)
+
         name = f"{image.id}.zarr"
         root = zarr.open(name)
         if "masks" in root.group_keys():
@@ -38,16 +65,28 @@ def image_masks_to_zarr(image, args):
         else:
             out_masks = root.create_group("masks")
 
+        mask_shape = list(image_shape)
+        for d in ignored_dimensions:
+            mask_shape[DIMENSION_ORDER[d]] = 1
+        print("Ignoring dimensions {}".format(ignored_dimensions))
+
         # TODO: Make each ROI a separate group and use Roi.id as name?
         roi_name = "0"
         za = out_masks.create_dataset(
             roi_name,
-            shape=image_shape,
-            chunks=(1, 1, size_z, size_y, size_x),
+            shape=mask_shape,
+            chunks=(1, 1, 1, size_y, size_x),
             dtype=np.int16,
             overwrite=True,
         )
-        masks_to_labels(masks, image_shape, check_overlaps=False, labels=za)
+        masks_to_labels(
+            masks,
+            mask_shape,
+            ignored_dimensions,
+            check_overlaps=True,
+            labels=za,
+        )
+
         # Setting za.attrs[] doesn't work, so go via parent
         if "0" in root:
             image_name = "0"
@@ -69,26 +108,18 @@ def image_masks_to_zarr(image, args):
         print("No masks found on Image")
 
 
-def mask_to_binim(mask, image_shape):
+def _mask_to_binim_yx(mask):
     """
     :param mask MaskI: An OMERO mask
-    :param image_shape 5-tuple: the image dimensions (T, C, Z, Y, X)
 
-    :return: Binary mask with the same dimensions as the image
-             If `T`, `C` or `Z` are not set on the mask the mask is expanded to
-             all planes in that dimension
+    :return: tuple of
+            - Binary mask
+            - (T, C, Z, Y, X, w, h) tuple of mask settings (T, C, Z may be
+              None)
 
     TODO: Move to https://github.com/ome/omero-rois/
     """
-    size_t, size_c, size_z, size_y, size_x = image_shape
 
-    def get_indicies(d, size_d):
-        if d is not None:
-            return [d]
-        return range(size_d)
-
-    # Create an nd-array same size as image
-    binim = np.zeros(image_shape, np.bool)
     t = unwrap(mask.theT)
     c = unwrap(mask.theC)
     z = unwrap(mask.theZ)
@@ -105,51 +136,115 @@ def mask_to_binim(mask, image_shape):
     # truncate and reshape
     binarray = np.reshape(binarray[: (w * h)], (h, w))
 
-    for i_t in get_indicies(t, size_t):
-        for i_c in get_indicies(c, size_c):
-            for i_z in get_indicies(z, size_z):
-                binim[i_t, i_c, i_z, y : (y + h), x : (x + w)] = binarray
+    return binarray, (t, c, z, y, x, h, w)
+
+
+def _get_indicies(ignored_dimensions, d, d_value, d_size):
+    """
+    Figures out which Z/C/T-planes a mask should be copied to
+    """
+    if d in ignored_dimensions:
+        return [0]
+    if d_value is not None:
+        return [d_value]
+    return range(d_size)
+
+
+def mask_to_binim(mask, mask_shape, ignored_dimensions):
+    """
+    :param mask MaskI: An OMERO mask
+    :param mask_shape 5-tuple: the image dimensions (T, C, Z, Y, X), taking
+           into account `ignored_dimensions`
+    :param ignored_dimensions set(char): Ignore these dimensions and set size
+           to 1
+
+    :return: Binary mask with the same dimensions as the image
+             If `T`, `C` or `Z` are not set on the mask the mask is expanded to
+             all planes in that dimension
+
+    TODO: Move to https://github.com/ome/omero-rois/
+    """
+    size_t, size_c, size_z, size_y, size_x = mask_shape
+
+    binim = np.zeros(mask_shape, np.bool)
+    binim_yx, (t, c, z, y, x, h, w) = _mask_to_binim_yx(mask)
+
+    for i_t in _get_indicies(ignored_dimensions, "T", t, size_t):
+        for i_c in _get_indicies(ignored_dimensions, "C", c, size_c):
+            for i_z in _get_indicies(ignored_dimensions, "Z", z, size_z):
+                binim[i_t, i_c, i_z, y : (y + h), x : (x + w)] = binim_yx
 
     return binim
 
 
-def masks_to_labels(masks, image_shape, check_overlaps, labels=None):
+def masks_to_labels(
+    masks,
+    mask_shape,
+    ignored_dimensions=None,
+    check_overlaps=True,
+    labels=None,
+):
     """
     :param masks [MaskI]: Iterable container of OMERO masks
-    :param image_shape 5-tuple: the image dimensions (T, C, Z, Y, X)
+    :param mask_shape 5-tuple: the image dimensions (T, C, Z, Y, X), taking
+           into account `ignored_dimensions`
+    :param ignored_dimensions set(char): Ignore these dimensions and set size
+           to 1
     :param check_overlaps bool: Whether to check for overlapping masks or not
     :param labels nd-array: The optional output array, pass this if you have
            already created the array and want to fill it.
 
-    :return: Label image with the same dimensions as the image
-             If `T`, `C` or `Z` are not set on the mask the labels are expanded
-             to all planes in that dimension
+    :return: Label image with size `mask_shape`
 
     TODO: Move to https://github.com/ome/omero-rois/
     """
 
-    # Create np nd-array same size as image
+    size_t, size_c, size_z, size_y, size_x = mask_shape
+    ignored_dimensions = ignored_dimensions or set()
+    mask_shape = tuple(mask_shape)
+
     if not labels:
         # TODO: Set np.int size based on number of labels
-        labels = np.zeros(image_shape, np.int16)
-    assert (
-        labels.shape == image_shape
-    ), "labels must have the same shape as the image"
+        labels = np.zeros(mask_shape, np.int16)
+
+    for d in "TCZYX":
+        if d in ignored_dimensions:
+            assert (
+                labels.shape[DIMENSION_ORDER[d]] == 1
+            ), "Ignored dimension {} should be size 1".format(d)
+        assert (
+            labels.shape == mask_shape
+        ), "Invalid label shape: {}, expected {}".format(
+            labels.shape, mask_shape
+        )
 
     for count, shapes in enumerate(masks.values()):
         # All shapes same color for each ROI
         print(count)
         for mask in shapes:
-            binim = mask_to_binim(mask, image_shape)
-            if check_overlaps and np.any(
-                np.logical_and(labels.astype(np.bool), binim)
-            ):
-                raise Exception(
-                    "Mask {} overlaps with existing labels".format(count)
-                )
-
-            # ADD to the array, so zeros in our binarray don't wipe out
-            # previous masks
-            labels[:] += binim * count
+            binim_yx, (t, c, z, y, x, h, w) = _mask_to_binim_yx(mask)
+            for i_t in _get_indicies(ignored_dimensions, "T", t, size_t):
+                for i_c in _get_indicies(ignored_dimensions, "C", c, size_c):
+                    for i_z in _get_indicies(
+                        ignored_dimensions, "Z", z, size_z
+                    ):
+                        if check_overlaps and np.any(
+                            np.logical_and(
+                                labels[
+                                    i_t, i_c, i_z, y : (y + h), x : (x + w)
+                                ].astype(np.bool),
+                                binim_yx,
+                            )
+                        ):
+                            raise Exception(
+                                "Mask {} overlaps with existing labels".format(
+                                    count
+                                )
+                            )
+                        # ADD to the array, so zeros in our binarray don't
+                        # wipe out previous masks
+                        labels[i_t, i_c, i_z, y : (y + h), x : (x + w)] += (
+                            binim_yx * count
+                        )
 
     return labels

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -15,7 +15,7 @@ DIMENSION_ORDER = {
 }
 
 MASK_DTYPE_SIZE = {
-    2: np.bool,
+    1: np.bool,
     8: np.int8,
     16: np.int16,
     32: np.int32,

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -100,8 +100,12 @@ def _save_masks(masks, image, roi_name, dtype):
         overwrite=True,
     )
     masks_to_labels(
-        masks, mask_shape, dtype,
-        ignored_dimensions, check_overlaps=True, labels=za,
+        masks,
+        mask_shape,
+        dtype,
+        ignored_dimensions,
+        check_overlaps=True,
+        labels=za,
     )
 
     # Setting za.attrs[] doesn't work, so go via parent


### PR DESCRIPTION
Effectively implements https://github.com/ome/omero-cli-zarr/pull/4 but with a hard-coded `0` for the mask name.

Main changes:
- Mask is stored under `IMAGEID.zarr/masks/0` instead of `IMAGEID_masks.zarr/0` (note the image data is optional, it is fine to have a mask without an image)
- Mask arrays are always 5D `(T, C, Z, Y, X)`
- Some mask dimensions may have size 1 instead of being the same size as the image. This indicates they should be expanded. E.g. If image `sizeC=3` but mask `sizeC=1` then the client should duplicate the mask for each `imageC`
- Adds some basic metadata to `IMAGEID.zarr/masks/0/.zattrs`, in particular `image.name` is the name of the image in the same Zarr. If the image is not included this is a URL to the remote image data.
- When creating a label image masks are checked for overlaps
- ~~`--group-rois`~~`--split-masks` flag will save each ROI in a separate group named `masks/<ROI-ID>` instead of putting everything under `masks/0`. This is required if you've got overlapping masks.
- `--mask-bits` argument sets the bit size of the label mask. Use `1` to create a binary mask.

- [x] https://github.com/ome/omero-cli-zarr/pull/7 Should go in first