### PR TITLE
Introduce 6D mask storage

### DIFF
--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -32,9 +32,9 @@ Options
 
   --style
 
+     'labelled': 5D integer values (default but overlaps are not supported!)
      '6d': masks are stored in a 6D array
      'split': one group per ROI
-     'labelled': 5D integer values (overlaps are not supported!)
 
 """
 
@@ -122,12 +122,12 @@ class ZarrControl(BaseControl):
         masks.add_argument(
             "--style",
             choices=("6d", "split", "labelled"),
-            default="6d",
+            default="labelled",
             help=("Choice of storage for ROIs"),
         )
         masks.add_argument(
             "--mask-bits",
-            default=str(min(MASK_DTYPE_SIZE.keys())),
+            default=str(max(MASK_DTYPE_SIZE.keys())),
             choices=[str(s) for s in sorted(MASK_DTYPE_SIZE.keys())],
             help=(
                 "Integer bit size for each mask pixel, use 1 for a binary "

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -15,9 +15,28 @@ from omero.model import ImageI
 from .raw_pixels import image_to_zarr
 from .masks import image_masks_to_zarr, MASK_DTYPE_SIZE
 
-HELP = "Export data in zarr format."
+HELP = """Export data in zarr format.
+
+Subcommands
+===========
+
+ - export
+ - masks
+
+"""
 EXPORT_HELP = "Export an image in zarr format."
-MASKS_HELP = "Export ROI Masks on the Image in zarr format."
+MASKS_HELP = """Export ROI Masks on the Image in zarr format.
+
+Options
+-------
+
+  --style
+
+     '6d': masks are stored in a 6D array
+     'split': one group per ROI
+     'labelled': 5D integer values (overlaps are not supported!)
+
+"""
 
 
 def gateway_required(func):
@@ -88,16 +107,27 @@ class ZarrControl(BaseControl):
             help="The Image from which to export Masks.",
         )
         masks.add_argument(
-            "--split-masks",
-            action="store_true",
+            "--mask-path",
+            help=("Subdirectory of the image location for storing masks"),
+            default="masks",
+        )
+        masks.add_argument(
+            "--mask-name",
             help=(
-                "Store each ROI in a separate group, required if masks "
-                "overlap"
+                "Name of the array that will be stored. "
+                "Ignored for --style=split"
             ),
+            default="0",
+        )
+        masks.add_argument(
+            "--style",
+            choices=("6d", "split", "labelled"),
+            default="6d",
+            help=("Choice of storage for ROIs"),
         )
         masks.add_argument(
             "--mask-bits",
-            default=str(max(MASK_DTYPE_SIZE.keys())),
+            default=str(min(MASK_DTYPE_SIZE.keys())),
             choices=[str(s) for s in sorted(MASK_DTYPE_SIZE.keys())],
             help=(
                 "Integer bit size for each mask pixel, use 1 for a binary "

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -142,9 +142,9 @@ class MaskSaver:
             self.stack_masks(
                 masks,
                 mask_shape,
+                za,
                 ignored_dimensions,
                 check_overlaps=True,
-                target=za,
             )
 
         # Setting za.attrs[] doesn't work, so go via parent
@@ -290,20 +290,20 @@ class MaskSaver:
         self,
         masks,
         mask_shape,
+        target,
         ignored_dimensions=None,
         check_overlaps=True,
-        target=None,
     ):
         """
         :param masks [MaskI]: Iterable container of OMERO masks
         :param mask_shape 5-tuple: the image dimensions (T, C, Z, Y, X), taking
             into account `ignored_dimensions`
+        :param target nd-array: The output array, pass this if you
+            have already created the array and want to fill it.
         :param ignored_dimensions set(char): Ignore these dimensions and set
             size to 1
         :param check_overlaps bool: Whether to check for overlapping masks or
             not
-        :param labels nd-array: The optional output array, pass this if you
-            have already created the array and want to fill it.
 
         :return: Array with one extra dimension than `mask_shape`
 

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -45,201 +45,308 @@ def image_masks_to_zarr(image, args):
 
     dtype = MASK_DTYPE_SIZE[int(args.mask_bits)]
 
+    if args.style == "labelled" and args.mask_bits == "1":
+        print("Boolean type makes no sense for labelled. Using 64")
+        dtype = MASK_DTYPE_SIZE[64]
+
     if masks:
-        if args.split_masks:
+        saver = MaskSaver(image, dtype, args.mask_path, args.style)
+        if args.style == "split":
             for (roi_id, roi) in masks.items():
-                _save_masks([roi], image, str(roi_id), dtype)
+                saver.save([roi], str(roi_id))
         else:
-            _save_masks(masks.values(), image, "0", dtype)
+            saver.save(masks.values(), args.mask_name)
     else:
         print("No masks found on Image")
 
 
-def _save_masks(masks, image, roi_name, dtype):
-    size_t = image.getSizeT()
-    size_c = image.getSizeC()
-    size_z = image.getSizeZ()
-    size_y = image.getSizeY()
-    size_x = image.getSizeX()
-    image_shape = (size_t, size_c, size_z, size_y, size_x)
-
-    # Figure out whether we can flatten some dimensions
-    unique_dims = {
-        "T": set(),
-        "C": set(),
-        "Z": set(),
-    }
-    for shapes in masks:
-        for mask in shapes:
-            unique_dims["T"].add(unwrap(mask.theT))
-            unique_dims["C"].add(unwrap(mask.theC))
-            unique_dims["Z"].add(unwrap(mask.theZ))
-    ignored_dimensions = set()
-    print(unique_dims)
-    for d in "TCZ":
-        if unique_dims[d] == {None}:
-            ignored_dimensions.add(d)
-
-    name = f"{image.id}.zarr"
-    root = zarr.open(name)
-    if "masks" in root.group_keys():
-        out_masks = root.masks
-    else:
-        out_masks = root.create_group("masks")
-
-    mask_shape = list(image_shape)
-    for d in ignored_dimensions:
-        mask_shape[DIMENSION_ORDER[d]] = 1
-    print("Ignoring dimensions {}".format(ignored_dimensions))
-
-    za = out_masks.create_dataset(
-        roi_name,
-        shape=mask_shape,
-        chunks=(1, 1, 1, size_y, size_x),
-        dtype=dtype,
-        overwrite=True,
-    )
-    masks_to_labels(
-        masks,
-        mask_shape,
-        dtype,
-        ignored_dimensions,
-        check_overlaps=True,
-        labels=za,
-    )
-
-    # Setting za.attrs[] doesn't work, so go via parent
-    if "0" in root:
-        image_name = "../../0"
-    else:
-        image_name = "omero://{}.zarr".format(image.id)
-    out_masks[roi_name].attrs["image"] = {
-        "array": image_name,
-        "source": {
-            # 'ts': [],
-            # 'cs': [],
-            # 'zs': [],
-            # 'ys': [],
-            # 'xs': [],
-        },
-    }
-
-    print("Created {}/masks/{}".format(name, roi_name))
-
-
-def _mask_to_binim_yx(mask, dtype):
-    """
-    :param mask MaskI: An OMERO mask
-    :param dtype Expected type of the output
-
-    :return: tuple of
-            - Binary mask
-            - (T, C, Z, Y, X, w, h) tuple of mask settings (T, C, Z may be
-              None)
-
-    TODO: Move to https://github.com/ome/omero-rois/
-    """
-
-    t = unwrap(mask.theT)
-    c = unwrap(mask.theC)
-    z = unwrap(mask.theZ)
-
-    x = int(mask.x.val)
-    y = int(mask.y.val)
-    w = int(mask.width.val)
-    h = int(mask.height.val)
-
-    mask_packed = mask.getBytes()
-    # convert bytearray into something we can use
-    intarray = np.fromstring(mask_packed, dtype=np.uint8)
-    binarray = np.unpackbits(intarray).astype(dtype)
-    # truncate and reshape
-    binarray = np.reshape(binarray[: (w * h)], (h, w))
-
-    return binarray, (t, c, z, y, x, h, w)
-
-
-def _get_indices(ignored_dimensions, d, d_value, d_size):
-    """
-    Figures out which Z/C/T-planes a mask should be copied to
-    """
-    if d in ignored_dimensions:
-        return [0]
-    if d_value is not None:
-        return [d_value]
-    return range(d_size)
-
-
-def masks_to_labels(
-    masks,
-    mask_shape,
-    dtype,
-    ignored_dimensions=None,
-    check_overlaps=True,
-    labels=None,
-):
-    """
-    :param masks [MaskI]: Iterable container of OMERO masks
-    :param mask_shape 5-tuple: the image dimensions (T, C, Z, Y, X), taking
-           into account `ignored_dimensions`
-    :param dtype Expected type of the converted masks
-    :param ignored_dimensions set(char): Ignore these dimensions and set size
-           to 1
-    :param check_overlaps bool: Whether to check for overlapping masks or not
-    :param labels nd-array: The optional output array, pass this if you have
-           already created the array and want to fill it.
-
-    :return: Label image with size `mask_shape`
-
-    TODO: Move to https://github.com/ome/omero-rois/
-    """
-
-    size_t, size_c, size_z, size_y, size_x = mask_shape
-    ignored_dimensions = ignored_dimensions or set()
-    mask_shape = tuple(mask_shape)
-
-    if not labels:
-        # TODO: Set np.int size based on number of labels
-        labels = np.zeros(mask_shape, np.int64)
-
-    for d in "TCZYX":
-        if d in ignored_dimensions:
-            assert (
-                labels.shape[DIMENSION_ORDER[d]] == 1
-            ), "Ignored dimension {} should be size 1".format(d)
-        assert (
-            labels.shape == mask_shape
-        ), "Invalid label shape: {}, expected {}".format(
-            labels.shape, mask_shape
+class MaskSaver:
+    def __init__(self, image, dtype, path="masks", style="6d"):
+        self.image = image
+        self.dtype = dtype
+        self.path = path
+        self.style = style
+        self.size_t = image.getSizeT()
+        self.size_c = image.getSizeC()
+        self.size_z = image.getSizeZ()
+        self.size_y = image.getSizeY()
+        self.size_x = image.getSizeX()
+        self.image_shape = (
+            self.size_t,
+            self.size_c,
+            self.size_z,
+            self.size_y,
+            self.size_x,
         )
 
-    for count, shapes in enumerate(masks):
-        # All shapes same color for each ROI
-        print(count)
-        for mask in shapes:
-            binim_yx, (t, c, z, y, x, h, w) = _mask_to_binim_yx(mask, dtype)
-            for i_t in _get_indices(ignored_dimensions, "T", t, size_t):
-                for i_c in _get_indices(ignored_dimensions, "C", c, size_c):
-                    for i_z in _get_indices(
-                        ignored_dimensions, "Z", z, size_z
-                    ):
-                        if check_overlaps and np.any(
-                            np.logical_and(
-                                labels[
-                                    i_t, i_c, i_z, y : (y + h), x : (x + w)
-                                ].astype(np.bool),
-                                binim_yx,
-                            )
-                        ):
-                            raise Exception(
-                                "Mask {} overlaps with existing labels".format(
-                                    count
-                                )
-                            )
-                        # ADD to the array, so zeros in our binarray don't
-                        # wipe out previous masks
-                        labels[i_t, i_c, i_z, y : (y + h), x : (x + w)] += (
-                            binim_yx * (count + 1)  # Prevent zeroing
-                        )
+    def save(self, masks, name):
 
-    return labels
+        # Figure out whether we can flatten some dimensions
+        unique_dims = {
+            "T": set(),
+            "C": set(),
+            "Z": set(),
+        }
+        for shapes in masks:
+            for mask in shapes:
+                unique_dims["T"].add(unwrap(mask.theT))
+                unique_dims["C"].add(unwrap(mask.theC))
+                unique_dims["Z"].add(unwrap(mask.theZ))
+        ignored_dimensions = set()
+        print(f"Unique dimensions: {unique_dims}")
+
+        for d in "TCZ":
+            if unique_dims[d] == {None}:
+                ignored_dimensions.add(d)
+
+        filename = f"{self.image.id}.zarr"
+        root = zarr.open(filename)
+        if self.path in root.group_keys():
+            out_masks = getattr(root, self.path)
+        else:
+            out_masks = root.create_group(self.path)
+
+        mask_shape = list(self.image_shape)
+        for d in ignored_dimensions:
+            mask_shape[DIMENSION_ORDER[d]] = 1
+        print("Ignoring dimensions {}".format(ignored_dimensions))
+
+        if self.style in ("labelled", "split"):
+
+            za = out_masks.create_dataset(
+                name,
+                shape=mask_shape,
+                chunks=(1, 1, 1, self.size_y, self.size_x),
+                dtype=self.dtype,
+                overwrite=True,
+            )
+
+            self.masks_to_labels(
+                masks,
+                mask_shape,
+                ignored_dimensions,
+                check_overlaps=True,
+                labels=za,
+            )
+
+        else:
+            assert self.style == "6d"
+            za = out_masks.create_dataset(
+                name,
+                shape=tuple([len(masks)] + mask_shape),
+                chunks=(1, 1, 1, 1, self.size_y, self.size_x),
+                dtype=self.dtype,
+                overwrite=True,
+            )
+
+            self.stack_masks(
+                masks,
+                mask_shape,
+                ignored_dimensions,
+                check_overlaps=True,
+                target=za,
+            )
+
+        # Setting za.attrs[] doesn't work, so go via parent
+        if "0" in root:
+            image_name = "../../0"
+        else:
+            image_name = "omero://{}.zarr".format(self.image.id)
+        out_masks[name].attrs["image"] = {
+            "array": image_name,
+            "source": {
+                # 'ts': [],
+                # 'cs': [],
+                # 'zs': [],
+                # 'ys': [],
+                # 'xs': [],
+            },
+        }
+
+        print(f"Created {filename}/{self.path}/{name}")
+
+    def _mask_to_binim_yx(self, mask):
+        """
+        :param mask MaskI: An OMERO mask
+
+        :return: tuple of
+                - Binary mask
+                - (T, C, Z, Y, X, w, h) tuple of mask settings (T, C, Z may be
+                None)
+
+        TODO: Move to https://github.com/ome/omero-rois/
+        """
+
+        t = unwrap(mask.theT)
+        c = unwrap(mask.theC)
+        z = unwrap(mask.theZ)
+
+        x = int(mask.x.val)
+        y = int(mask.y.val)
+        w = int(mask.width.val)
+        h = int(mask.height.val)
+
+        mask_packed = mask.getBytes()
+        # convert bytearray into something we can use
+        intarray = np.fromstring(mask_packed, dtype=np.uint8)
+        binarray = np.unpackbits(intarray).astype(self.dtype)
+        # truncate and reshape
+        binarray = np.reshape(binarray[: (w * h)], (h, w))
+
+        return binarray, (t, c, z, y, x, h, w)
+
+    def _get_indices(self, ignored_dimensions, d, d_value, d_size):
+        """
+        Figures out which Z/C/T-planes a mask should be copied to
+        """
+        if d in ignored_dimensions:
+            return [0]
+        if d_value is not None:
+            return [d_value]
+        return range(d_size)
+
+    def masks_to_labels(
+        self,
+        masks,
+        mask_shape,
+        ignored_dimensions=None,
+        check_overlaps=True,
+        labels=None,
+    ):
+        """
+        :param masks [MaskI]: Iterable container of OMERO masks
+        :param mask_shape 5-tuple: the image dimensions (T, C, Z, Y, X), taking
+            into account `ignored_dimensions`
+        :param ignored_dimensions set(char): Ignore these dimensions and set
+            size to 1
+        :param check_overlaps bool: Whether to check for overlapping masks or
+            not
+        :param labels nd-array: The optional output array, pass this if you
+            have already created the array and want to fill it.
+
+        :return: Label image with size `mask_shape`
+
+        TODO: Move to https://github.com/ome/omero-rois/
+        """
+
+        size_t, size_c, size_z, size_y, size_x = mask_shape
+        ignored_dimensions = ignored_dimensions or set()
+        mask_shape = tuple(mask_shape)
+
+        if not labels:
+            # TODO: Set np.int size based on number of labels
+            labels = np.zeros(mask_shape, np.int64)
+
+        for d in "TCZYX":
+            if d in ignored_dimensions:
+                assert (
+                    labels.shape[DIMENSION_ORDER[d]] == 1
+                ), "Ignored dimension {} should be size 1".format(d)
+            assert (
+                labels.shape == mask_shape
+            ), "Invalid label shape: {}, expected {}".format(
+                labels.shape, mask_shape
+            )
+
+        for count, shapes in enumerate(masks):
+            # All shapes same color for each ROI
+            print(count)
+            for mask in shapes:
+                binim_yx, (t, c, z, y, x, h, w) = self._mask_to_binim_yx(mask)
+                for i_t in self._get_indices(
+                    ignored_dimensions, "T", t, size_t
+                ):
+                    for i_c in self._get_indices(
+                        ignored_dimensions, "C", c, size_c
+                    ):
+                        for i_z in self._get_indices(
+                            ignored_dimensions, "Z", z, size_z
+                        ):
+                            if check_overlaps and np.any(
+                                np.logical_and(
+                                    labels[
+                                        i_t, i_c, i_z, y : (y + h), x : (x + w)
+                                    ].astype(np.bool),
+                                    binim_yx,
+                                )
+                            ):
+                                raise Exception(
+                                    (
+                                        f"Mask {count} overlaps "
+                                        "with existing labels"
+                                    )
+                                )
+                            # ADD to the array, so zeros in our binarray don't
+                            # wipe out previous masks
+                            labels[
+                                i_t, i_c, i_z, y : (y + h), x : (x + w)
+                            ] += (
+                                binim_yx * (count + 1)  # Prevent zeroing
+                            )
+
+        return labels
+
+    def stack_masks(
+        self,
+        masks,
+        mask_shape,
+        ignored_dimensions=None,
+        check_overlaps=True,
+        target=None,
+    ):
+        """
+        :param masks [MaskI]: Iterable container of OMERO masks
+        :param mask_shape 5-tuple: the image dimensions (T, C, Z, Y, X), taking
+            into account `ignored_dimensions`
+        :param ignored_dimensions set(char): Ignore these dimensions and set
+            size to 1
+        :param check_overlaps bool: Whether to check for overlapping masks or
+            not
+        :param labels nd-array: The optional output array, pass this if you
+            have already created the array and want to fill it.
+
+        :return: Array with one extra dimension than `mask_shape`
+
+        TODO: Move to https://github.com/ome/omero-rois/
+        """
+
+        size_t, size_c, size_z, size_y, size_x = mask_shape
+        ignored_dimensions = ignored_dimensions or set()
+        mask_shape = tuple(mask_shape)
+
+        if not target:
+            raise Exception("No target")
+
+        for d in "TCZYX":
+            if d in ignored_dimensions:
+                assert (
+                    target.shape[DIMENSION_ORDER[d] + 1] == 1
+                ), "Ignored dimension {} should be size 1".format(d)
+            assert target.shape == tuple(
+                [len(masks)] + list(mask_shape)
+            ), "Invalid label shape: {}, expected {}".format(
+                target.shape, mask_shape
+            )
+            assert True
+
+        for count, shapes in enumerate(masks):
+            # All shapes same color for each ROI
+            print(count)
+            for mask in shapes:
+                binim_yx, (t, c, z, y, x, h, w) = self._mask_to_binim_yx(mask)
+                for i_t in self._get_indices(
+                    ignored_dimensions, "T", t, size_t
+                ):
+                    for i_c in self._get_indices(
+                        ignored_dimensions, "C", c, size_c
+                    ):
+                        for i_z in self._get_indices(
+                            ignored_dimensions, "Z", z, size_z
+                        ):
+                            target[
+                                count, i_t, i_c, i_z, y : (y + h), x : (x + w)
+                            ] += (
+                                binim_yx  # Here one could assign probabilities
+                            )
+
+        return target

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -140,11 +140,7 @@ class MaskSaver:
             )
 
             self.stack_masks(
-                masks,
-                mask_shape,
-                za,
-                ignored_dimensions,
-                check_overlaps=True,
+                masks, mask_shape, za, ignored_dimensions, check_overlaps=True,
             )
 
         # Setting za.attrs[] doesn't work, so go via parent


### PR DESCRIPTION
Follow on from https://github.com/ome/omero-cli-zarr/pull/8#discussion_r446173666 that introduces a third option for storage of masks called, 6d, which can be chosen along with the other options:

 * `--style=labelled` for the single 5D labelled image
 * `--style=split` for several 5D images, named after the ROI

Converting the 6D array back into a labelled image can be done with:

```
s = zarr.open("path/to/6d/array")
shape = list(s.shape)[1:]
chunks = list(s.chunks)[1:]
a = zarr.zeros(shape, chunks=chunks, dtype='i8')
a = np.zeros(shape, dtype='i8')
for x in range(s.shape[0]):
    a[s[x]] = x + 1
viewer.add_labels(a, name="masks")
Out[8]: <Labels layer 'masks' at 0x7fb209b0b320>
```

Testing with:

```
rm -rf 6001240.zarr/{masks,6d,labelled,split};for x in "6d" "labelled" "split"; do time omero zarr masks --style=$x --mask-path=$x Image:6001240; done
```

Note the difference in size:

```
9.3M	6001240.zarr/6d
1.6M	6001240.zarr/labelled
```

stemming from numpy's storage of a bool in 8-bits. See:
 - https://github.com/pydata/xarray/issues/2937
 - https://stackoverflow.com/questions/5602155/numpy-boolean-array-with-1-bit-entries