### PR TITLE
Add missing omero_zarr package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="omero-cli-zarr",
     version="0.0.1",
-    packages=["", "omero.plugins"],
+    packages=["omero_zarr", "omero.plugins"],
     package_dir={"": "src"},
     description="Plugin for exporting images in zarr format.",
     url="",


### PR DESCRIPTION
I suspect this previously worked because the package was installed in editable mode.

Testing: `omero zarr ...` should work after `pip install .` (no `-e`) in a clean environment