### PR TITLE
Add mask-map logic

### DIFF
--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -134,6 +134,13 @@ class ZarrControl(BaseControl):
                 "mask, default %(default)s"
             ),
         )
+        masks.add_argument(
+            "--mask-map",
+            help=(
+                "File in format: ID,NAME,ROI_ID which is used to separate "
+                "overlapping masks"
+            ),
+        )
 
         export = parser.add(sub, self.export, EXPORT_HELP)
         export.add_argument(

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -272,7 +272,7 @@ class MaskSaver:
             for mask in shapes:
                 # Unused metadata: the{ZTC}, x, y, width, height, textValue
                 if mask.fillColor:
-                    fillColors[count+1] = unwrap(mask.fillColor)
+                    fillColors[count + 1] = unwrap(mask.fillColor)
                 binim_yx, (t, c, z, y, x, h, w) = self._mask_to_binim_yx(mask)
                 for i_t in self._get_indices(
                     ignored_dimensions, "T", t, size_t

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -1,6 +1,8 @@
 import omero.clients  # noqa
 from omero.model import MaskI
 from omero.rtypes import unwrap
+from collections import defaultdict
+from fileinput import input
 import numpy as np
 import zarr
 
@@ -55,7 +57,26 @@ def image_masks_to_zarr(image, args):
             for (roi_id, roi) in masks.items():
                 saver.save([roi], str(roi_id))
         else:
-            saver.save(masks.values(), args.mask_name)
+            if args.mask_map:
+
+                mask_map = defaultdict(list)
+                roi_map = {}
+                for (roi_id, roi) in masks.items():
+                    roi_map[roi_id] = roi
+
+                try:
+                    for line in input(args.mask_map):
+                        line = line.strip()
+                        id, name, roi = line.split(",")
+                        mask_map[name].append(roi_map[int(roi)])
+                except Exception as e:
+                    print(f"Error parsing {args.mask_map}: {e}")
+
+                for name, values in mask_map.items():
+                    print(f"Mask map: {name} (count: {len(values)})")
+                    saver.save(values, name)
+            else:
+                saver.save(masks.values(), args.mask_name)
     else:
         print("No masks found on Image")
 
@@ -244,10 +265,14 @@ class MaskSaver:
                 labels.shape, mask_shape
             )
 
+        fillColors = {}
         for count, shapes in enumerate(masks):
             # All shapes same color for each ROI
             print(count)
             for mask in shapes:
+                # Unused metadata: the{ZTC}, x, y, width, height, textValue
+                if mask.fillColor:
+                    fillColors[count+1] = unwrap(mask.fillColor)
                 binim_yx, (t, c, z, y, x, h, w) = self._mask_to_binim_yx(mask)
                 for i_t in self._get_indices(
                     ignored_dimensions, "T", t, size_t
@@ -280,6 +305,7 @@ class MaskSaver:
                                 binim_yx * (count + 1)  # Prevent zeroing
                             )
 
+        labels.attrs["color"] = fillColors
         return labels
 
     def stack_masks(


### PR DESCRIPTION
Follow-on from #9. Allows splitting overlapping labelled images into separate arrays under `masks/`.

### Setup:

```
omero zarr export Image:5514375
omero hql --style=plain "select distinct s.textValue, s.roi.id from Shape s where s.roi.image.id = 5514375" --limit=-1 | tee 5514375.rois
omero zarr masks Image:5514375 --mask-map=5514375.rois
```

### Testing code:

```
#!/usr/bin/env python
import napari
import zarr



imagename = "5514375.zarr"
masks = zarr.open(f"{imagename}/masks")

with napari.gui_qt():
    viewer = napari.Viewer()
    viewer.open(f"{imagename}")

    def to_rgba(v):
        return [int(x) for x in v.to_bytes(4, signed=True, byteorder='big')]

    for name in ("Cell", "Chromosomes"):
        mask = masks[name]
        colors = mask.attrs["color"]
        colors = {int(k):to_rgba(v) for (k, v) in colors.items()}
        viewer.add_labels(mask, name=name, color=colors)
```

### Background reading
 - https://github.com/napari/napari/pull/1362
 - https://github.com/napari/napari/issues/1356
 - https://forum.image.sc/t/specify-labels-colors/31534/2
 - https://github.com/tlambert03/napari-omero/pull/17 (for round-tripping)