### PR TITLE
Add mask export args to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This OMERO command-line plugin allows you to export images from
 OMERO as zarr files, according to the spec at 
 https://github.com/ome/omero-ms-zarr/blob/master/spec.md.
 
+These are 5D arrays of shape `(t, c, z, y, x)`.
+
 It supports export using 2 alternative methods:
 
 - By default the OMERO API is used to load planes as numpy arrays
@@ -43,9 +45,62 @@ $ omero zarr export 1 --bf --output /home/user/zarr_files
 Image exported to /home/user/zarr_files/2chZT.lsm
 ```
 
-To export masks for an image:
+To export masks for an Image:
 
 ```
-# Creates a group "masks" under zarr_files/1.zarr
-$ omero zarr masks 1 --output /home/user/zarr_files
+# Saved under zarr_files/1.zarr/masks/0
+$ omero zarr masks Image:1 --output /home/user/zarr_files
+
+# Specify the mask-path (default 'masks').
+# e.g. Export to 1.zarr/my_masks:
+$ omero zarr masks Image:1 mask-path=my_masks
+
+# Specify the mask-name. (default is '0')
+# e.g. Export to 1.zarr/masks/A
+$ omero zarr masks Image:1 mask-name=A
+```
+
+The default behaviour is to export all masks on the Image to a single 5D
+"labelled" zarr array, with a different value for each mask Shape.
+An exception will be thrown if any of the masks overlap.
+
+To handle overlapping masks, you can export as a 6D zarr array or
+split one zarr group per ROI, using ROI ID as the group name.
+
+```
+# 6D mask saved under 1.zarr/masks/0
+$ omero zarr masks Image:1 --style=6d
+
+# each mask saved under 1.zarr/masks/ROI_ID/
+$ omero zarr masks Image:1 --style=split
+```
+
+An alternative is to save multiple Masks into each zarr group,
+using a "mask-map" which is a csv file of that specifies the name of
+the zarr group for each ROI on the Image. Columns are ID, NAME, ROI_ID.
+
+For example, to create a group from the `textValue` of each Shape,
+you can use this command:
+
+```
+omero hql --style=plain "select distinct s.textValue, s.roi.id from Shape s where s.roi.image.id = 5514375" --limit=-1 | tee 5514375.rois
+```
+
+This creates a file `5514375.rois` like this:
+
+```
+0,Cell,1369132
+1,Cell,1369134
+2,Cell,1369136
+...
+40,Chromosomes,1369131
+41,Chromosomes,1369133
+42,Chromosomes,1369135
+...
+```
+
+This will create zarr groups of `Cell` and `Chromosomes` under `5514375.zarr/masks/`:
+
+```
+$ omero zarr masks Image:5514375 --mask-map=5514375.rois
 ```

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ $ omero zarr masks Image:1 --output /home/user/zarr_files
 
 # Specify the mask-path (default 'masks').
 # e.g. Export to 1.zarr/my_masks:
-$ omero zarr masks Image:1 mask-path=my_masks
+$ omero zarr masks Image:1 --mask-path=my_masks
 
 # Specify the mask-name. (default is '0')
 # e.g. Export to 1.zarr/masks/A
-$ omero zarr masks Image:1 mask-name=A
+$ omero zarr masks Image:1 --mask-name=A
 ```
 
 The default behaviour is to export all masks on the Image to a single 5D

--- a/README.md
+++ b/README.md
@@ -64,18 +64,7 @@ The default behaviour is to export all masks on the Image to a single 5D
 "labelled" zarr array, with a different value for each mask Shape.
 An exception will be thrown if any of the masks overlap.
 
-To handle overlapping masks, you can export as a 6D zarr array or
-split one zarr group per ROI, using ROI ID as the group name.
-
-```
-# 6D mask saved under 1.zarr/masks/0
-$ omero zarr masks Image:1 --style=6d
-
-# each mask saved under 1.zarr/masks/ROI_ID/
-$ omero zarr masks Image:1 --style=split
-```
-
-An alternative is to save multiple Masks into each zarr group,
+To handle overlapping masks, split masks into non-overlapping zarr groups
 using a "mask-map" which is a csv file of that specifies the name of
 the zarr group for each ROI on the Image. Columns are ID, NAME, ROI_ID.
 


### PR DESCRIPTION
Add instructions from #9 and #11.

I realise that these arguments are described in the cli help, but I find them easier to find and understand when you can read them on the page.
Also includes hql for creating mask-map.