### PR TITLE
Improve bioformats2raw export

### DIFF
--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -172,10 +172,10 @@ class ZarrControl(BaseControl):
                 prx, desc = self.client.getManagedRepository(description=True)
                 repo_path = Path(desc._path._val) / Path(desc._name._val)
                 if inplace:
-                    for p in image.getImportedImageFilePaths()['client_paths']:
-                        self._bf_export(Path('/') / Path(p), args)
+                    for p in image.getImportedImageFilePaths()["client_paths"]:
+                        self._bf_export(Path("/") / Path(p), args)
                 else:
-                    for p in image.getImportedImageFilePaths()['server_paths']:
+                    for p in image.getImportedImageFilePaths()["server_paths"]:
                         self._bf_export(repo_path / p, args)
             else:
                 image_to_zarr(image, args)
@@ -202,11 +202,15 @@ class ZarrControl(BaseControl):
         if args.max_workers:
             options += " --max_workers=" + args.max_workers
 
-        self.ctx.dbg("bioformats2raw %s %s %s" % (options, abs_path.resolve(),
-                                                  target.resolve()))
+        self.ctx.dbg(
+            "bioformats2raw %s %s %s"
+            % (options, abs_path.resolve(), target.resolve())
+        )
         process = subprocess.Popen(
-            ["bioformats2raw", options, abs_path.resolve(),
-             target.resolve()], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            ["bioformats2raw", options, abs_path.resolve(), target.resolve()],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         stdout, stderr = process.communicate()
         if stderr:
             self.ctx.err(stderr)

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -217,7 +217,7 @@ class ZarrControl(BaseControl):
             cwd=bf2raw,)
         stdout, stderr = process.communicate()
         if stderr:
-            print(stderr)
+            self.ctx.err(stderr)
         else:
             self.ctx.out("Image exported to {}".format(target.resolve()))
 

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -172,11 +172,11 @@ class ZarrControl(BaseControl):
                 prx, desc = self.client.getManagedRepository(description=True)
                 repo_path = Path(desc._path._val) / Path(desc._name._val)
                 if inplace:
-                    for path in image.getImportedImageFilePaths()['client_paths']:
-                        self._bf_export(Path('/') / Path(path), args)
+                    for p in image.getImportedImageFilePaths()['client_paths']:
+                        self._bf_export(Path('/') / Path(p), args)
                 else:
-                    for path in image.getImportedImageFilePaths()['server_paths']:
-                        self._bf_export(repo_path / path, args)
+                    for p in image.getImportedImageFilePaths()['server_paths']:
+                        self._bf_export(repo_path / p, args)
             else:
                 image_to_zarr(image, args)
 


### PR DESCRIPTION
- Use `image.getImportedImageFilePaths()` to get the file paths to the image. This should solve https://github.com/ome/omero-cli-zarr/issues/15 ?
- When using `--bf` it is now expected that the bioformats2raw binary is in the `$PATH`; no setting of environment variable necessary any longer.
- Get the path to the managed repo from the `client`; again remove the necessasity of an environment variable.
- The various bioformats2raw options are now only part of the 'export' subcommand.

**Test:** Add the `bioformats2raw/bin` directory to the `$PATH` and run something like `omero zarr export --bf Image:123` Would be good to test with "normal" and "inplace imported" image.
