### PR TITLE
Labels: change colors to array

### DIFF
--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -272,14 +272,16 @@ class MaskSaver:
                 labels.shape, mask_shape
             )
 
-        fillColors = {}
+        fillColors = [None]
         for count, shapes in enumerate(masks):
             # All shapes same color for each ROI
             print(count)
             for mask in shapes:
                 # Unused metadata: the{ZTC}, x, y, width, height, textValue
                 if mask.fillColor:
-                    fillColors[count + 1] = unwrap(mask.fillColor)
+                    fillColors.append(unwrap(mask.fillColor))
+                else:
+                    fillColors.append(None)
                 binim_yx, (t, c, z, y, x, h, w) = self._mask_to_binim_yx(mask)
                 for i_t in self._get_indices(
                     ignored_dimensions, "T", t, size_t

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -276,12 +276,11 @@ class MaskSaver:
         for count, shapes in enumerate(masks):
             # All shapes same color for each ROI
             print(count)
+            maskColor = None
             for mask in shapes:
                 # Unused metadata: the{ZTC}, x, y, width, height, textValue
-                if mask.fillColor:
-                    fillColors.append(unwrap(mask.fillColor))
-                else:
-                    fillColors.append(None)
+                if mask.fillColor and maskColor is None:
+                    maskColor = unwrap(mask.fillColor)
                 binim_yx, (t, c, z, y, x, h, w) = self._mask_to_binim_yx(mask)
                 for i_t in self._get_indices(
                     ignored_dimensions, "T", t, size_t
@@ -313,6 +312,8 @@ class MaskSaver:
                             ] += (
                                 binim_yx * (count + 1)  # Prevent zeroing
                             )
+            fillColors.append(maskColor)
+            assert len(fillColors) == count + 2
 
         labels.attrs["color"] = fillColors
         return labels


### PR DESCRIPTION
label colors is an array of length (number of labels + 1), containing `null` if no colour is assigned

Currently it's a map of strings-representing-integers to colors, this changes it to be an array.

- See https://github.com/ome/omero-ms-zarr/issues/62
- This is an alternative proposal to https://github.com/ome/omero-cli-zarr/pull/24