### PR TITLE
Multiscale support

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,0 +1,11 @@
+name: Precommit
+on: [push, pull_request]
+jobs:
+  # https://github.com/pre-commit/action
+  pre-commit:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv/
 .idea/
 *.iml
+*egg-info
 build/
 dist/
-src/__pycache__/
+__pycache__

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = numpy,ome_zarr,omero,omero_zarr,setuptools,zarr

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,84 @@
+---
 repos:
-- repo: https://github.com/ambv/black
-  rev: 19.10b0
-  hooks:
-  - id: black
-    # default black line length is 88
-    args:
-      - --target-version=py35
-      - --line-length=79
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
-  hooks:
-  - id: flake8
-    args:
-      # flake8 is not PEP8 compliant
-      # https://black.readthedocs.io/en/stable/the_black_code_style.html
-      - --ignore=E203,W503
-    # default flake8 line length is 79
+
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.3
+    hooks:
+      - id: seed-isort-config
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.3.2
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        args: [--target-version=py36]
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.2
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py36-plus
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-json
+        files: \.(json)$
+      - id: check-yaml
+      - id: fix-encoding-pragma
+        args:
+          - --remove
+      - id: trailing-whitespace
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: pretty-format-json
+        args:
+          - --autofix
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8
+        additional_dependencies: [
+          flake8-blind-except,
+          flake8-builtins,
+          flake8-rst-docstrings,
+          flake8-logging-format,
+        ]
+        args: [
+          # default black line length is 88
+          "--max-line-length=88",
+          # Conflicts with black: E203 whitespace before ':'
+          "--ignore=E203",
+          "--rst-roles=class,func,ref,module,const",
+        ]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.782
+    hooks:
+      - id: mypy
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.782
+    hooks:
+      - id: mypy
+        args: [
+          --disallow-untyped-defs,
+          --ignore-missing-imports,
+        ]
+        exclude: tests/*|setup.py
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.24.2
+    hooks:
+      - id: yamllint
+        # args: [--config-data=relaxed]
+        #

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ OMERO CLI Zarr plugin
 =====================
 
 This OMERO command-line plugin allows you to export images from
-OMERO as zarr files, according to the spec at 
+OMERO as zarr files, according to the spec at
 https://github.com/ome/omero-ms-zarr/blob/master/spec.md.
 
 These are 5D arrays of shape `(t, c, z, y, x)`.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To export images via the OMERO API:
 $ omero zarr export Image:1
 
 # Specify an output directory
-$ omero zarr export Image:1 --output /home/user/zarr_files
+$ omero zarr --output /home/user/zarr_files export Image:1
 
 # Cache each plane as a numpy file.npy. If connection is lost, and you need
 # to export again, we can use these instead of downloading again
@@ -41,7 +41,7 @@ To export images via bioformats2raw we use the ```--bf``` flag:
 export MANAGED_REPO=/var/omero/data/ManagedRepository
 export BF2RAW=/opt/tools/bioformats2raw-0.2.0-SNAPSHOT
 
-$ omero zarr export 1 --bf --output /home/user/zarr_files
+$ omero zarr --output /home/user/zarr_files export 1 --bf
 Image exported to /home/user/zarr_files/2chZT.lsm
 ```
 
@@ -49,7 +49,7 @@ To export masks for an Image:
 
 ```
 # Saved under zarr_files/1.zarr/labels/0
-$ omero zarr masks Image:1 --output /home/user/zarr_files
+$ omero zarr --output /home/user/zarr_files masks Image:1
 
 # Specify the label-path (default 'labels').
 # e.g. Export to 1.zarr/my_labels:

--- a/src/omero/plugins/zarr.py
+++ b/src/omero/plugins/zarr.py
@@ -1,3 +1,3 @@
-from omero_zarr.cli import ZarrControl, HELP
+from omero_zarr.cli import HELP, ZarrControl
 
-register("zarr", ZarrControl, HELP)  # noqa
+register("zarr", ZarrControl, HELP)  # type: ignore # noqa

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -107,9 +107,7 @@ class ZarrControl(BaseControl):
         )
         masks.add_argument(
             "--label-name",
-            help=(
-                "Name of the array that will be stored. " "Ignored for --style=split"
-            ),
+            help=("Name of the array that will be stored. Ignored for --style=split"),
             default="0",
         )
         masks.add_argument(

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -35,7 +35,6 @@ Options
   --style
 
      'labeled': 5D integer values (default but overlaps are not supported!)
-     '6d': masks are stored in a 6D array
      'split': one group per ROI
 
 """
@@ -115,7 +114,7 @@ class ZarrControl(BaseControl):
         )
         masks.add_argument(
             "--style",
-            choices=("6d", "split", "labeled"),
+            choices=("split", "labeled"),
             default="labeled",
             help=("Choice of storage for ROIs [breaks ome-zarr]"),
         )

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -91,6 +91,14 @@ class ZarrControl(BaseControl):
             help="The Image from which to export Masks.",
         )
         masks.add_argument(
+            "--source-image",
+            help=(
+                "Path to the multiscales group containing the source image. "
+                "By default, use the output directory"
+            ),
+            default=None,
+        )
+        masks.add_argument(
             "--label-path",
             help=(
                 "Subdirectory of the image location for storing labels. "

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -35,7 +35,7 @@ def image_masks_to_zarr(image: omero.gateway.Image, args: argparse.Namespace) ->
 
     conn = image._conn
     roi_service = conn.getRoiService()
-    result = roi_service.findByImage(image.id, None)
+    result = roi_service.findByImage(image.id, None, {"omero.group": "-1"})
 
     masks = {}
     shape_count = 0

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -7,7 +7,7 @@ import numpy as np
 import omero.clients  # noqa
 from ome_zarr.data import write_multiscale
 from ome_zarr.io import parse_url
-from ome_zarr.reader import Layer, Multiscales
+from ome_zarr.reader import Multiscales, Node
 from ome_zarr.scale import Scaler
 from omero.model import MaskI
 from omero.rtypes import unwrap
@@ -148,7 +148,7 @@ class MaskSaver:
 
         src = parse_url(source_image)
         assert src
-        input_pyramid = Layer(src, [])
+        input_pyramid = Node(src, [])
         assert input_pyramid.load(Multiscales)
         input_pyramid_levels = len(input_pyramid.data)
 

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -55,11 +55,8 @@ def image_masks_to_zarr(image, args):
     if masks:
 
         saver = MaskSaver(
-            image,
-            dtype,
-            args.label_path,
-            args.style,
-            args.source_image)
+            image, dtype, args.label_path, args.style, args.source_image
+        )
 
         if args.style == "split":
             for (roi_id, roi) in masks.items():
@@ -187,7 +184,6 @@ class MaskSaver:
             self.stack_masks(
                 masks, mask_shape, za, ignored_dimensions, check_overlaps=True,
             )
-
 
         out_labels[name].attrs["image"] = {
             "array": source_image_link,

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -140,9 +140,12 @@ class MaskSaver:
             # Assume that we're using the output directory
             source_image = filename
             source_image_link = "../.."  # Drop "labels/0"
+
         src = ome_zarr.parse_url(source_image)
+        assert src
 
         root = zarr.open(filename)
+        # TODO: Use ome-zarr here to write a multiscale?
         if self.path in root.group_keys():
             out_labels = getattr(root, self.path)
         else:

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -309,7 +309,7 @@ class MaskSaver:
                                 )
                             ):
                                 raise Exception(
-                                    f"Mask {count} overlaps " "with existing labels"
+                                    f"Mask {count} overlaps with existing labels"
                                 )
                             # ADD to the array, so zeros in our binarray don't
                             # wipe out previous masks

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -6,8 +6,7 @@ import numpy
 import numpy as np
 import omero.clients  # noqa
 from omero.rtypes import unwrap
-from zarr.hierarchy import open_group
-from zarr.storage import Group
+from zarr.hierarchy import Group, open_group
 
 
 def image_to_zarr(image: omero.gateway.Image, args: argparse.Namespace) -> None:


### PR DESCRIPTION
 - Use `ome_zarr.scale` to generate multiscale labels
 - Improve link to source image metadata
 - Drop support for 6D
 - Fix README for `--output` (fix #26)