### PR TITLE
Row column names

### DIFF
--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -139,6 +139,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
     row_names = set()
     col_names = set()
     ac_names = set()
+    paths = set()
 
     for well in plate.listChildren():
         row = plate.getRowLabels()[well.row]
@@ -154,6 +155,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
                 ac = ws.getPlateAcquisition()
                 ac_name = ac.getName() if ac else "0"
                 ac_names.add(ac_name)
+                paths.add(f"{ac_name}/{row}/{col}/{field_name}")
                 ac_group = root.require_group(ac_name)
                 row_group = ac_group.require_group(row)
                 col_group = row_group.require_group(col)
@@ -168,6 +170,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
         "row_names": list(row_names),
         "col_names": list(col_names),
         "plateAcquisitions": {"path": x for x in ac_names},
+        "images": {"path": x for x in paths},
     }
     root.attrs["plate"] = plate_metadata
     print("Finished.")

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -167,10 +167,10 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
     plate_metadata = {
         "rows": n_rows,
         "columns": n_cols,
-        "row_names": list(row_names),
-        "col_names": list(col_names),
-        "plateAcquisitions": {"path": x for x in ac_names},
-        "images": {"path": x for x in paths},
+        "row_names": sorted(list(row_names)),
+        "column_names": sorted(list(col_names)),
+        "plateAcquisitions": [{"path": x} for x in ac_names],
+        "images": [{"path": x} for x in paths],
     }
     root.attrs["plate"] = plate_metadata
     print("Finished.")

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -9,7 +9,7 @@ import numpy as np
 import omero.clients  # noqa
 from omero.rtypes import unwrap
 from zarr.hierarchy import Group, open_group
-import json
+
 
 def image_to_zarr(image: omero.gateway.ImageWrapper, args: argparse.Namespace) -> None:
     target_dir = args.output
@@ -162,12 +162,13 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
                 add_group_metadata(field_group, img, n_levels)
             print_status(int(t0), int(time.time()), count, total)
 
-    plate_metadata = {"rows": n_rows,
-                      "columns": n_cols,
-                      "row_names": list(row_names),
-                      "col_names": list(col_names),
-                      "plateAcquisitions": dict(("path", x) for x in ac_names)
-                      }
+    plate_metadata = {
+        "rows": n_rows,
+        "columns": n_cols,
+        "row_names": list(row_names),
+        "col_names": list(col_names),
+        "plateAcquisitions": {"path": x for x in ac_names},
+    }
     root.attrs["plate"] = plate_metadata
     print("Finished.")
 


### PR DESCRIPTION
Add acquisition, row and column names to the metadata. 

Example:
```
> cat 51.zarr/.zattrs 
{
    "plate": {
        "col_names": [
            1,
            2,
            3,
            4,
            5,
            6,
            7,
            8,
            9,
            10,
            11,
            12
        ],
        "columns": 12,
        "plateAcquisitions": {
            "path": "Run 51"
        },
        "row_names": [
            "F",
            "E",
            "H",
            "A",
            "G",
            "B",
            "D",
            "C"
        ],
        "rows": 8
    }
}
```
Shall I rather 'break' the previous code and use `rows` instead of `row_names`? 

Addresses https://github.com/ome/omero-cli-zarr/issues/31 .

/cc @will-moore 