### PR TITLE
Re close

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ omero zarr --output /home/user/zarr_files export Image:1
 
 # Cache each plane as a numpy file.npy. If connection is lost, and you need
 # to export again, we can use these instead of downloading again
-# omero zarr export Image:1 --cache_numpy
+# omero zarr --cache_numpy export Image:1
 
 ```
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -211,11 +211,7 @@ def add_group_metadata(
     zarr_root.attrs["multiscales"] = multiscales
     zarr_root.attrs["omero"] = image_data
 
-    try:
-        if image._re is not None:
-            image._re.close()
-    except Exception:
-        print("Failed to close rendering engine")
+    image._closeRE()
 
 
 def channelMarshal(channel: omero.model.Channel) -> Dict[str, Any]:

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -211,6 +211,12 @@ def add_group_metadata(
     zarr_root.attrs["multiscales"] = multiscales
     zarr_root.attrs["omero"] = image_data
 
+    try:
+        if image._re is not None:
+            image._re.close()
+    except Exception:
+        print("Failed to close rendering engine")
+
 
 def channelMarshal(channel: omero.model.Channel) -> Dict[str, Any]:
     return {


### PR DESCRIPTION
Feedback from @sbesson suggests that https://github.com/ome/omero-cli-zarr/pull/29/commits/330099f75209edbc4c1c4e5e2dec1c91eee7c183 is causing FileHandle issues when exporting plates with lots of images, probably because rendering engines not being closed for each image.

This closes rendering engine.