### PR TITLE
Fix conditional statement to skip PyPI publication for forks rather than tags

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build-n-publish:
     name: Publish to PyPI
-    if: startsWith(github.ref, 'refs/tags')
+    if: github.repository_owner == 'ome'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Also uses a generic check on `repository_owner` to prevent failures on forks