### PR TITLE
Remove publication to test PyPI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -5,7 +5,6 @@ on: push
 jobs:
   build-n-publish:
     name: Publish to PyPI
-    if: github.repository_owner == 'ome'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,12 +13,6 @@ jobs:
         run: |
           python -mpip install wheel
           python setup.py sdist bdist_wheel
-      - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.0
-        with:
-          skip_existing: true
-          password: ${{ secrets.TEST_PYPI_PASSWORD }}
-          repository_url: https://test.pypi.org/legacy/
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@v1.3.0


### PR DESCRIPTION
Originally motivated by https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-the-distribution-to-pypi-and-testpypi,
the continuous delivery to test PyPI failed for two separate reasons:
- distributions with the same version cannot be overwritten
- dev version generated by setuptools_scm are generally PEP440 incompatible

Partly reverts #37, see also the discussion https://github.com/ome/omero-cli-zarr/pull/33. This PR preserves the PyPI publication workflow on tags (and runs the packaging command for every push so that we would spot broken builds)