### PR TITLE
Well metadata

### DIFF
--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -153,7 +153,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
         "name": plate.name,
         "rows": [{"name": str(name)} for name in row_names],
         "columns": [{"name": str(name)} for name in col_names],
-        "plateAcquisitions": [{"path": x} for x in ac_names],
+        "acquisitions": [{"path": x} for x in ac_names],
     }
     root.attrs["plate"] = plate_metadata
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -164,7 +164,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
         well_paths = []
         for field in range(n_fields[0], n_fields[1] + 1):
             ws = well.getWellSample(field)
-            field_name = "Field_{}".format(field + 1)
+            field_name = "%d" % field
             count += 1
             if ws and ws.getImage():
                 img = ws.getImage()

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -142,7 +142,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
 
     row_names = set()
     col_names = set()
-    paths = set()
+    well_paths = set()
 
     col_names = plate.getColumnLabels()
     row_names = plate.getRowLabels()
@@ -160,7 +160,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
     for well in plate.listChildren():
         row = plate.getRowLabels()[well.row]
         col = plate.getColumnLabels()[well.column]
-        well_paths = []
+        field_paths = []
         for field in range(n_fields[0], n_fields[1] + 1):
             ws = well.getWellSample(field)
             field_name = "%d" % field
@@ -169,8 +169,8 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
                 img = ws.getImage()
                 ac = ws.getPlateAcquisition()
                 ac_name = ac.getName() if ac else "0"
-                paths.add(f"{ac_name}/{row}/{col}/{field_name}")
-                well_paths.append(field_name)
+                well_paths.add(f"{ac_name}/{row}/{col}/")
+                field_paths.append(f"{field_name}/")
                 ac_group = root.require_group(ac_name)
                 row_group = ac_group.require_group(row)
                 col_group = row_group.require_group(col)
@@ -178,12 +178,12 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
                 n_levels = add_image(img, field_group, cache_dir=cache_dir)
                 add_group_metadata(field_group, img, n_levels)
                 # Update Well metadata after each image
-                col_group.attrs["well"] = {"images": [{"path": x} for x in well_paths]}
+                col_group.attrs["well"] = {"images": [{"path": x} for x in field_paths]}
                 max_fields = max(max_fields, field + 1)
             print_status(int(t0), int(time.time()), count, total)
 
         # Update plate_metadata after each Well
-        plate_metadata["images"] = [{"path": x} for x in paths]
+        plate_metadata["wells"] = [{"path": x} for x in well_paths]
         plate_metadata["field_count"] = max_fields
         root.attrs["plate"] = plate_metadata
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -198,13 +198,16 @@ def print_status(t0: int, t: int, count: int, total: int) -> None:
         count: number of tasks done
         total: total number of tasks
     """
-    percent_done = float(count) * 100 / total
-    rate = float(count) / (t - t0)
-    eta = float(total - count) / rate
-    status = "{:.2f}% done, ETA: {}".format(
-        percent_done, time.strftime("%H:%M:%S", time.gmtime(eta))
-    )
-    print(status, end="\r", flush=True)
+    try:
+        percent_done = float(count) * 100 / total
+        rate = float(count) / (t - t0)
+        eta = float(total - count) / rate
+        status = "{:.2f}% done, ETA: {}".format(
+            percent_done, time.strftime("%H:%M:%S", time.gmtime(eta))
+        )
+        print(status, end="\r", flush=True)
+    except ZeroDivisionError:
+        pass
 
 
 def add_group_metadata(

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -151,8 +151,8 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
 
     plate_metadata = {
         "name": plate.name,
-        "rows": [{"name": name} for name in row_names],
-        "columns": [{"name": name} for name in col_names],
+        "rows": [{"name": str(name)} for name in row_names],
+        "columns": [{"name": str(name)} for name in col_names],
         "plateAcquisitions": [{"path": x} for x in ac_names],
     }
     root.attrs["plate"] = plate_metadata


### PR DESCRIPTION
See https://github.com/ome/omero-ms-zarr/issues/76#issuecomment-721068552

`omero zarr export Plate:1` now exports 'well' metadata like

```
"well": {
    "images": [
        {"path": "0"},
        {"path": "1"}
    ]
}
```

and 'plate' metadata like:

```
"plate": {
        "columns": [
            {"name": "1"}, {"name": "2"}, {"name": "3"}
        ],
        "rows": [
            {"name": "A"}, {"name": "B"}
        ],
        "wells": [
            {"path": "0/A/3"},
            {"path": "0/B/2"},
            {"path": "0/A/1"},
            {"path": "0/B/3"},
            {"path": "0/A/2"},
            {"path": "0/B/1"}
        ],
        "field_count": 1,
        "name": "plate1_1_013",
        "acquisitions": [
            {"path": "0"}
        ],
    }
```