### PR TITLE
Export plate masks

### DIFF
--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -9,7 +9,7 @@ from omero.cli import CLI, BaseControl, Parser, ProxyStringType
 from omero.gateway import BlitzGateway, BlitzObjectWrapper
 from omero.model import ImageI, PlateI
 
-from .masks import MASK_DTYPE_SIZE, image_masks_to_zarr
+from .masks import MASK_DTYPE_SIZE, image_masks_to_zarr, plate_masks_to_zarr
 from .raw_pixels import image_to_zarr, plate_to_zarr
 
 HELP = """Export data in zarr format.
@@ -92,7 +92,7 @@ class ZarrControl(BaseControl):
         masks.add_argument(
             "--source-image",
             help=(
-                "Path to the multiscales group containing the source image. "
+                "Path to the multiscales group containing the source image/plate. "
                 "By default, use the output directory"
             ),
             default=None,
@@ -161,6 +161,9 @@ class ZarrControl(BaseControl):
             image = self._lookup(self.gateway, "Image", image_id)
             self.ctx.out("Export Masks on Image: %s" % image.name)
             image_masks_to_zarr(image, args)
+        elif isinstance(args.object, PlateI):
+            plate = self._lookup(self.gateway, "Plate", args.object.id)
+            plate_masks_to_zarr(plate, args)
 
     @gateway_required
     def export(self, args: argparse.Namespace) -> None:

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -58,7 +58,7 @@ def plate_masks_to_zarr(
         col = plate.getColumnLabels()[well.column]
         for field in range(n_fields[0], n_fields[1] + 1):
             ws = well.getWellSample(field)
-            field_name = "Field_{}".format(field + 1)
+            field_name = "%d" % field
             count += 1
             if ws and ws.getImage():
                 img = ws.getImage()
@@ -249,6 +249,7 @@ class MaskSaver:
         else:
             current_path = self.path
 
+        print(f"source_image {source_image}")
         src = parse_url(source_image)
         assert src, "Source image does not exist"
         input_pyramid = Node(src, [])

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -62,9 +62,7 @@ def plate_masks_to_zarr(
             count += 1
             if ws and ws.getImage():
                 img = ws.getImage()
-                ac = ws.getPlateAcquisition()
-                ac_name = ac.getName() if ac else "0"
-                plate_path = f"{ac_name}/{row}/{col}/{field_name}"
+                plate_path = f"{row}/{col}/{field_name}"
                 saver.set_image(img, plate_path)
                 masks = get_masks(img)
                 if masks:

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -393,7 +393,6 @@ class MaskSaver:
         fillColors: Dict[int, str] = {}
         for count, shapes in enumerate(masks):
             # All shapes same color for each ROI
-            print(count)
             for mask in shapes:
                 # Unused metadata: the{ZTC}, x, y, width, height, textValue
                 if mask.fillColor:

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -245,7 +245,7 @@ class MaskSaver:
         if self.plate:
             assert self.plate_path, "Need image path within the plate"
             source_image = f"{source_image}/{self.plate_path}"
-            current_path = f"{self.path}/{self.plate_path}"
+            current_path = f"{self.plate_path}/{self.path}"
         else:
             current_path = self.path
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -141,8 +141,6 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
     max_fields = 0
     t0 = time.time()
 
-    row_names = set()
-    col_names = set()
     well_paths = set()
 
     col_names = plate.getColumnLabels()

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -11,6 +11,7 @@ from omero.rtypes import unwrap
 from zarr.hierarchy import Group, open_group
 
 from . import __version__
+from .util import print_status
 
 
 def image_to_zarr(image: omero.gateway.ImageWrapper, args: argparse.Namespace) -> None:
@@ -189,25 +190,6 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
 
     add_toplevel_metadata(root)
     print("Finished.")
-
-
-def print_status(t0: int, t: int, count: int, total: int) -> None:
-    """ Prints percent done and ETA.
-        t0: start timestamp in seconds
-        t: current timestamp in seconds
-        count: number of tasks done
-        total: total number of tasks
-    """
-    try:
-        percent_done = float(count) * 100 / total
-        rate = float(count) / (t - t0)
-        eta = float(total - count) / rate
-        status = "{:.2f}% done, ETA: {}".format(
-            percent_done, time.strftime("%H:%M:%S", time.gmtime(eta))
-        )
-        print(status, end="\r", flush=True)
-    except ZeroDivisionError:
-        pass
 
 
 def add_group_metadata(

--- a/src/omero_zarr/util.py
+++ b/src/omero_zarr/util.py
@@ -1,0 +1,20 @@
+import time
+
+
+def print_status(t0: int, t: int, count: int, total: int) -> None:
+    """ Prints percent done and ETA.
+        t0: start timestamp in seconds
+        t: current timestamp in seconds
+        count: number of tasks done
+        total: total number of tasks
+    """
+    percent_done = float(count) * 100 / total
+    dt = t - t0
+    if dt > 0:
+        rate = float(count) / (t - t0)
+        eta_f = float(total - count) / rate
+        eta = time.strftime("%H:%M:%S", time.gmtime(eta_f))
+    else:
+        eta = "NA"
+    status = f"{percent_done:.2f}% done, ETA: {eta}"
+    print(status, end="\r", flush=True)


### PR DESCRIPTION
Adds the functionality for exporting masks/labels for plates.

It exports the masks in a path structure like this:
```
13855.zarr:
...
0/A/1/Field_1/0/0.0.0.0.0
0/A/1/Field_1/0/0.1.0.0.0
...
0/A/1/Field_1/labels/0/0/0.0.0.0.0
0/A/1/Field_1/labels/0/0/0.0.0.0.1
...
```

For testing I used plate `plate1_1_013` on merge-ci (user-3), doesn't take too long to export (about 10-15 min the first time).
```
omero zarr --cache_numpy export Plate:13855
omero zarr masks Plate:13855
```

Or create your own masks with a simple segmentation. I pasted a script together (based on idr0079 maks import script): https://gist.github.com/dominikl/0c65cc18d57b51c509e93e53c1c44bc6 .

Waiting for #43 to merged, will rebase then.