### PR TITLE
label properties

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.7
+current_version = 0.0.8.dev0
 commit = True
 tag = True
 sign_tags = True

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.8
+current_version = 0.0.9.dev0
 commit = True
 tag = True
 sign_tags = True

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.7.dev0
+current_version = 0.0.7
 commit = True
 tag = True
 sign_tags = True

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.8.dev0
+current_version = 0.0.8
 commit = True
 tag = True
 sign_tags = True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = cv2,numpy,ome_zarr,omero,omero_zarr,setuptools,zarr
+known_third_party = cv2,numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = get_long_description()
 
 setup(
     name="omero-cli-zarr",
-    version="0.0.8",
+    version="0.0.9.dev0",
     packages=["omero_zarr", "omero.plugins"],
     package_dir={"": "src"},
     description="Plugin for exporting images in zarr format.",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = get_long_description()
 
 setup(
     name="omero-cli-zarr",
-    version="0.0.7",
+    version="0.0.8.dev0",
     packages=["omero_zarr", "omero.plugins"],
     package_dir={"": "src"},
     description="Plugin for exporting images in zarr format.",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = get_long_description()
 
 setup(
     name="omero-cli-zarr",
-    version="0.0.8.dev0",
+    version="0.0.8",
     packages=["omero_zarr", "omero.plugins"],
     package_dir={"": "src"},
     description="Plugin for exporting images in zarr format.",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = get_long_description()
 
 setup(
     name="omero-cli-zarr",
-    version="0.0.7.dev0",
+    version="0.0.7",
     packages=["omero_zarr", "omero.plugins"],
     package_dir={"": "src"},
     description="Plugin for exporting images in zarr format.",

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -294,21 +294,28 @@ class MaskSaver:
             assert False, "6d has been removed"
 
         # Create and store binary data
-        labels, fill_colors = self.masks_to_labels(
+        labels, fill_colors, properties = self.masks_to_labels(
             masks, mask_shape, ignored_dimensions, check_overlaps=True,
         )
         scaler = Scaler(max_layer=input_pyramid_levels)
         label_pyramid = scaler.nearest(labels)
-        pyramid_grp = out_labels.create_group(name)
+        pyramid_grp = out_labels.require_group(name)
+
         write_multiscale(label_pyramid, pyramid_grp)  # TODO: dtype, chunks, overwite
 
         # Specify and store metadata
         image_label_colors: List[JSONDict] = []
+        label_properties: List[JSONDict] = []
         image_label = {
             "version": "0.1",
             "colors": image_label_colors,
+            "properties": label_properties,
             "source": {"image": source_image_link},
         }
+        if properties:
+            for label_value, props_dict in sorted(properties.items()):
+                new_dict: Dict = {"label-value": label_value, **props_dict}
+                label_properties.append(new_dict)
         if fill_colors:
             for label_value, rgba_int in sorted(fill_colors.items()):
                 image_label_colors.append(
@@ -416,16 +423,20 @@ class MaskSaver:
         mask_shape: Tuple[int, ...],
         ignored_dimensions: Set[str] = None,
         check_overlaps: bool = True,
-    ) -> Tuple[np.ndarray, Dict[int, str]]:
+    ) -> Tuple[np.ndarray, Dict[int, str], Dict[int, Dict]]:
         """
         :param masks [MaskI]: Iterable container of OMERO masks
         :param mask_shape 5-tuple: the image dimensions (T, C, Z, Y, X), taking
             into account `ignored_dimensions`
+
         :param ignored_dimensions set(char): Ignore these dimensions and set
             size to 1
+
         :param check_overlaps bool: Whether to check for overlapping masks or
             not
-        :return: Label image with size `mask_shape` as well as color metadata.
+
+        :return: Label image with size `mask_shape` as well as color metadata
+            and dict of other properties.
 
 
         TODO: Move to https://github.com/ome/omero-rois/
@@ -450,12 +461,22 @@ class MaskSaver:
             ), f"Invalid label shape: {labels.shape}, expected {mask_shape}"
 
         fillColors: Dict[int, str] = {}
+        properties: Dict[int, Dict] = {}
+
         for count, shapes in enumerate(masks):
-            # All shapes same color for each ROI
             for shape in shapes:
-                # Unused metadata: the{ZTC}, x, y, width, height, textValue
+                # Using ROI ID allows stitching label from multiple images
+                # into a Plate and not creating duplicates from different iamges.
+                # All shapes will be the same value (color) for each ROI
+                shape_value = shape.roi.id.val
+                properties[shape_value] = {
+                    "omero:shapeId": shape.id.val,
+                    "omero:roiId": shape.roi.id.val,
+                }
+                if shape.textValue:
+                    properties[shape_value]["omero:text"] = unwrap(shape.textValue)
                 if shape.fillColor:
-                    fillColors[count + 1] = unwrap(shape.fillColor)
+                    fillColors[shape_value] = unwrap(shape.fillColor)
                 binim_yx, (t, c, z, y, x, h, w) = self.shape_to_binim_yx(shape)
                 for i_t in self._get_indices(ignored_dimensions, "T", t, size_t):
                     for i_c in self._get_indices(ignored_dimensions, "C", c, size_c):
@@ -471,12 +492,12 @@ class MaskSaver:
                                 )
                             ):
                                 raise Exception(
-                                    f"Mask {count} overlaps with existing labels"
+                                    f"Mask {shape_value} overlaps with existing labels"
                                 )
                             # ADD to the array, so zeros in our binarray don't
-                            # wipe out previous masks
+                            # wipe out previous shapes
                             labels[i_t, i_c, i_z, y : (y + h), x : (x + w)] += (
-                                binim_yx * (count + 1)  # Prevent zeroing
+                                binim_yx * shape_value
                             )
 
-        return labels, fillColors
+        return labels, fillColors, properties

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -166,6 +166,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
         "name": plate.name,
         "rows": [{"name": str(name)} for name in row_names],
         "columns": [{"name": str(name)} for name in col_names],
+        "version": "0.1",
     }
     # Add acquisitions key if at least one plate acquisition exists
     acquisitions = list(plate.listPlateAcquisitions())
@@ -195,7 +196,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
                 n_levels = add_image(img, field_group, cache_dir=cache_dir)
                 add_group_metadata(field_group, img, n_levels)
                 # Update Well metadata after each image
-                col_group.attrs["well"] = {"images": fields}
+                col_group.attrs["well"] = {"images": fields, "version": "0.1"}
                 max_fields = max(max_fields, field + 1)
             print_status(int(t0), int(time.time()), count, total)
 
@@ -220,6 +221,7 @@ def add_group_metadata(
             "defaultZ": image._re.getDefaultZ(),
             "defaultT": image._re.getDefaultT(),
         },
+        "version": "0.1",
     }
     multiscales = [
         {"version": "0.1", "datasets": [{"path": str(r)} for r in range(resolutions)]}

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -162,14 +162,15 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
     col_names = plate.getColumnLabels()
     row_names = plate.getRowLabels()
 
-    acquisitions = [marshal_acquisition(pa) for pa in plate.listPlateAcquisitions()]
-
     plate_metadata = {
         "name": plate.name,
         "rows": [{"name": str(name)} for name in row_names],
         "columns": [{"name": str(name)} for name in col_names],
-        "acquisitions": acquisitions,
     }
+    # Add acquisitions key if at least one plate acquisition exists
+    acquisitions = list(plate.listPlateAcquisitions())
+    if acquisitions:
+        plate_metadata["acquisitions"] = [marshal_acquisition(x) for x in acquisitions]
     root.attrs["plate"] = plate_metadata
 
     for well in plate.listChildren():


### PR DESCRIPTION
Adds `properties` to labels `.zattrs` exported from OMERO.

See functionality tests below. But first question is probably what we want to name these properties and if we want them included by default or only with a cli argument?

```
        "properties": [
            {
                "label-value": 1,
                "omero:roiId": 212825,
                "omero:shapeId": 390575
            },
```

To Test - need an Image or Plate with masks
 - `omero zarr export Image or Plate`
 - `omero zarr masks (same Image or Plate)`
 - Open the `image/labels/0/.zattrs` in a text editor to see properties.
 - And/or `napari path/to/image` with `ome-zarr-py` at https://github.com/ome/ome-zarr-py/pull/61 installed should display properties when you mouse-over a mask. 