### PR TITLE
Skip acquisitions key if no plate acquisition exists

### DIFF
--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -162,14 +162,15 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
     col_names = plate.getColumnLabels()
     row_names = plate.getRowLabels()
 
-    acquisitions = [marshal_acquisition(pa) for pa in plate.listPlateAcquisitions()]
-
     plate_metadata = {
         "name": plate.name,
         "rows": [{"name": str(name)} for name in row_names],
         "columns": [{"name": str(name)} for name in col_names],
-        "acquisitions": acquisitions,
     }
+    # Add acquisitions key if at least one plate acquisition exists
+    acquisitions = plate.listPlateAcquisitions()
+    if acquisitions:
+        plate_metadata["acquisitions"] = [marshal_acquisition(x) for x in acquisitions]
     root.attrs["plate"] = plate_metadata
 
     for well in plate.listChildren():

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -168,7 +168,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
         "columns": [{"name": str(name)} for name in col_names],
     }
     # Add acquisitions key if at least one plate acquisition exists
-    acquisitions = plate.listPlateAcquisitions()
+    acquisitions = list(plate.listPlateAcquisitions())
     if acquisitions:
         plate_metadata["acquisitions"] = [marshal_acquisition(x) for x in acquisitions]
     root.attrs["plate"] = plate_metadata


### PR DESCRIPTION
While working on https://github.com/ome/ngff/pull/5 and creating representative plates using `omero-cli-zarr 0.0.7`, I realized that an `acquisitions` key is always created in the plate metadata even if no plate acquisitions are defined. At the well-metadata, `acquisition` is skipped if the field of view is not associated with an acquisition.

This unifies the behavior by making `acquisitions` truly optional in the case there is a single plate acquisition with no associated metadata.