### PR TITLE
Add 'polygons' command like 'masks'

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = cv2,numpy,ome_zarr,omero,omero_zarr,setuptools,zarr
+known_third_party = cv2,numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr


### PR DESCRIPTION
Support export of Polygons on an Image (or Plate) to labels.

To test, find an Image with Polygons e.g. on idr0001 image:

```
$ omero zarr export Image:1229801
$ omero zarr polygons Image:1229801
$ napari 1229801.zarr
```

<img width="931" alt="Screenshot 2020-11-26 at 23 37 07" src="https://user-images.githubusercontent.com/900055/100397281-b6eda580-3040-11eb-8f30-e5f1f40e224b.png">

