### PR TITLE
Use ome_zarr.writer from ome_zarr PR 69

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = cv2,numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr
+known_third_party = numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr


### PR DESCRIPTION
Testing only!

This is testing the ome_zarr.writer added in https://github.com/ome/ome-zarr-py/pull/69
However, this requires that we load the whole 5D image into a 5D numpy array before
passing this to the writer. This works for images with not too many Z/T planes, but
could fail for big stacks / time-lapse images.