### PR TITLE
Fix --bf option for bioformats2raw 0.3.0

### DIFF
--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, List
 
 from omero.cli import CLI, BaseControl, Parser, ProxyStringType
 from omero.gateway import BlitzGateway, BlitzObjectWrapper
@@ -268,23 +268,25 @@ class ZarrControl(BaseControl):
 
     def _bf_export(self, abs_path: Path, args: argparse.Namespace) -> None:
         target = (Path(args.output) or Path.cwd()) / Path(abs_path).name
-        target.mkdir(exist_ok=True)
 
-        options = "--file_type=zarr"
+        cmd: List[str] = [
+            "bioformats2raw",
+            str(abs_path.resolve()),
+            str(target.resolve()),
+        ]
+
         if args.tile_width:
-            options += " --tile_width=" + args.tile_width
+            cmd.append(f"--tile_width={args.tile_width}")
         if args.tile_height:
-            options += " --tile_height=" + args.tile_height
+            cmd.append(f"--tile_height={args.tile_height}")
         if args.resolutions:
-            options += " --resolutions=" + args.resolutions
+            cmd.append(f"--resolutions={args.resolutions}")
         if args.max_workers:
-            options += " --max_workers=" + args.max_workers
+            cmd.append(f"--max_workers={args.max_workers}")
 
-        self.ctx.dbg(
-            f"bioformats2raw {options} {abs_path.resolve()} {target.resolve()}"
-        )
+        self.ctx.dbg(" ".join(cmd))
         process = subprocess.Popen(
-            ["bioformats2raw", options, abs_path.resolve(), target.resolve()],
+            cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -290,9 +290,8 @@ class ZarrControl(BaseControl):
         )
         stdout, stderr = process.communicate()
         if stderr:
-            self.ctx.err(stderr)
-        else:
-            self.ctx.out(f"Image exported to {target.resolve()}")
+            self.ctx.err(stderr.decode("utf-8"))
+        self.ctx.out(f"Image exported to {target.resolve()}")
 
 
 try:

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -293,7 +293,8 @@ class ZarrControl(BaseControl):
         stdout, stderr = process.communicate()
         if stderr:
             self.ctx.err(stderr.decode("utf-8"))
-        self.ctx.out(f"Image exported to {target.resolve()}")
+        if process.returncode == 0:
+            self.ctx.out(f"Image exported to {target.resolve()}")
 
 
 try:


### PR DESCRIPTION
The breaking changes of bioformat2raw 0.3.0 has broken `omero zarr export --bf`. These commits provide the minimal set of changes to restore the command functionality. This currently _only_ support bioformats2raw 0.3.0 and drops support for 0.2.x but see below for the discussion on the flag support:

Tested on `pilot-zarr1-dev` with `omero --debug DEBUG zarr export --bf Image:13422206`.

This initial work raises a few high-level questions on the future of this option. As a general rule, most of the support and testing has been added to the OMERO-only export workflow. This means most of the nice recent features do not apply to the `--bf` option like the rendering setting in the Zarr metadata, the HCS support... Additionally the layout of the OMERO export is different from the `bioformats2raw` export since the latter works at the fileset level rather than the image level.

I can conceive two general export strategies:

-  either we want to keep a single `omero zarr export` command with two export path i.e. OMERO API vs bioformat2raw
- or we want to separate the commands i.e. let consumers invoke `bioformats2raw` first followed by a second command that would 1- update the layout, 2- enrich the OME-Zarr metadata. This workflow is what https://github.com/IDR/idr-zarr-tools/blob/master/merge.py currently aims at doing. Arguably this could be generalized as a subcommand of this plugin e.g. `omero zarr update` as the code will be effectively duplicated.
