### PR TITLE
bioformats2raw export: unify Zarr layout and add OMERO metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     rev: 5.9.3
     hooks:
       - id: isort
+        args: ["--profile", "black"]
 
   - repo: https://github.com/psf/black
     rev: 21.7b0

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -196,19 +196,29 @@ class ZarrControl(BaseControl):
         export.add_argument(
             "--bf",
             action="store_true",
-            help="Use bioformats2raw to export the image.",
+            help="Use bioformats2raw to export the image. Requires"
+            " bioformats2raw 0.3.0 or higher.",
         )
         export.add_argument(
-            "--tile_width", default=None, help="For use with bioformats2raw"
+            "--tile_width",
+            default=None,
+            help="Maximum tile width to read (only for use with bioformats2raw)",
         )
         export.add_argument(
-            "--tile_height", default=None, help="For use with bioformats2raw"
+            "--tile_height",
+            default=None,
+            help="Maximum tile height to read (only for use with bioformats2raw)",
         )
         export.add_argument(
-            "--resolutions", default=None, help="For use with bioformats2raw"
+            "--resolutions",
+            default=None,
+            help="Number of pyramid resolutions to generate"
+            " (only for use with bioformats2raw)",
         )
         export.add_argument(
-            "--max_workers", default=None, help="For use with bioformats2raw"
+            "--max_workers",
+            default=None,
+            help="Maximum number of workers (only for use with bioformats2raw)",
         )
         export.add_argument(
             "object",

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -266,6 +266,12 @@ class ZarrControl(BaseControl):
             p = image.getImportedImageFilePaths()["server_paths"][0]
             abs_path = Path(desc._path._val) / Path(desc._name._val) / Path(p)
         target = (Path(args.output) or Path.cwd()) / Path(abs_path).name
+        image_target = (Path(args.output) or Path.cwd()) / f"{image.id}.zarr"
+
+        if target.exists():
+            self.ctx.die(111, f"{target.resolve()} already exists")
+        if image_target.exists():
+            self.ctx.die(111, f"{image_target.resolve()} already exists")
 
         cmd: List[str] = [
             "bioformats2raw",
@@ -296,10 +302,9 @@ class ZarrControl(BaseControl):
             self.ctx.err(stderr.decode("utf-8"))
         if process.returncode == 0:
             image_source = target / "0"
-            image_dest = (Path(args.output) or Path.cwd()) / f"{image.id}.zarr"
-            image_source.rename(image_dest)
+            image_source.rename(image_target)
             target.rmdir()
-            self.ctx.out(f"Image exported to {image_dest.resolve()}")
+            self.ctx.out(f"Image exported to {image_target.resolve()}")
 
 
 try:


### PR DESCRIPTION
Follow-up of #75, this PR:

- unifies the layout of the generated Zarr to comply with the format of `omero export Image:<id>`. The image series is passed to bioformats2raw and the unique image group (`<fileset>/0`) is renamed as `<id>.zarr`
- separates the multiscale metadata addition from the omero metadata addition in `raw_pixels`
- adds the omero and creator metadata to the Zarr generated by bioformats2raw

The `add_omero_metadata` and `add_toplevel_metadata` are arguably outside the scope of the `raw_pixels` module and could be moved elsewhere (`utils`? new module?)