### PR TITLE
Remove opencv dependency

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = cv2,numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr
+known_third_party = numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -3,12 +3,12 @@ import os
 import time
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
-import cv2
 import numpy
 import numpy as np
 import omero.clients  # noqa
 import omero.gateway  # required to allow 'from omero_zarr import raw_pixels'
 from omero.rtypes import unwrap
+from skimage.transform import resize
 from zarr.hierarchy import Array, Group, open_group
 from zarr.storage import FSStore
 
@@ -185,11 +185,13 @@ def add_raw_image(
 
                     if (level + 1) < level_count:
                         # resize for next level...
-                        plane = cv2.resize(
+                        plane = resize(
                             plane,
-                            dsize=(size_x // 2, size_y // 2),
-                            interpolation=cv2.INTER_NEAREST,
-                        )
+                            output_shape=(size_x // 2, size_y // 2),
+                            order=0,
+                            preserve_range=True,
+                            anti_aliasing=False,
+                        ).astype(plane.dtype)
     return (level_count, axes + ["y", "x"])
 
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -187,7 +187,7 @@ def add_raw_image(
                         # resize for next level...
                         plane = resize(
                             plane,
-                            output_shape=(size_x // 2, size_y // 2),
+                            output_shape=(size_y // 2, size_x // 2),
                             order=0,
                             preserve_range=True,
                             anti_aliasing=False,


### PR DESCRIPTION
Previously, the CLI plugin relied on the `opencv` dependency transitively through `ome-zarr-py`. However, this dependency has been dropped as part of the 0.3 specification support in https://github.com/ome/ome-zarr-py/pull/89. With the release of `ome-zarr-py==0.0.24`, @dominikl has established the  standard installation of `omero-cli-zarr` is currently broken (without a manual installation of the dependency):

```
(zarr) ➜  Downloads omero zarr --help
Error loading: /Users/dom/miniconda3/envs/zarr/lib/python3.9/site-packages/omero/plugins/zarr.py
Traceback (most recent call last):
  File "/Users/dom/miniconda3/envs/zarr/lib/python3.9/site-packages/omero/cli.py", line 1690, in loadpath
    execfile(str(pathobj), loc)
  File "/Users/dom/miniconda3/envs/zarr/lib/python3.9/site-packages/past/builtins/misc.py", line 87, in execfile
    exec_(code, myglobals, mylocals)
  File "/Users/dom/miniconda3/envs/zarr/lib/python3.9/site-packages/omero/plugins/zarr.py", line 1, in <module>
    from omero_zarr.cli import HELP, ZarrControl
  File "/Users/dom/miniconda3/envs/zarr/lib/python3.9/site-packages/omero_zarr/cli.py", line 13, in <module>
    from .raw_pixels import image_to_zarr, plate_to_zarr
  File "/Users/dom/miniconda3/envs/zarr/lib/python3.9/site-packages/omero_zarr/raw_pixels.py", line 6, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'
usage: /Users/dom/miniconda3/envs/zarr/bin/omero [-h] [-v] [-d DEBUG]
                                                 [--path PATH] [-C]
                                                 [-s SERVER] [-p PORT]
                                                 [-g GROUP] [-u USER]
                                                 [-w PASSWORD] [-k KEY]
                                                 [--sudo ADMINUSER] [-q]
                                                 <subcommand> ...
/Users/dom/miniconda3/envs/zarr/bin/omero: error: argument <subcommand>: invalid choice: 'zarr'

choose from:
	admin, chgrp, chown, config, db, delete, download, errors, export,
	fs, group, help, hql, import, ldap, load, login, logout, node,
	obj, perf, quit, script, search, sessions, shell, tag, testengine,
	upload, user, version
```


This PR proposes to fix this installation issue and align the downsampling implementation to use the same library as `ome-zarr-py`. 

A follow-up refactoring would probably be to delegate the downsampling logic to a relevant `ome-zarr-py` API. @will-moore 