### PR TITLE
Support exporting dataset

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr
+known_third_party = dask,numpy,ome_zarr,omero,omero_model_DatasetI,omero_zarr,setuptools,skimage,zarr

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, List
 from omero.cli import CLI, BaseControl, Parser, ProxyStringType
 from omero.gateway import BlitzGateway, BlitzObjectWrapper
 from omero.model import ImageI, PlateI
+from omero_model_DatasetI import DatasetI
 from zarr.hierarchy import open_group
 from zarr.storage import FSStore
 
@@ -16,7 +17,7 @@ from .raw_pixels import (
     add_omero_metadata,
     add_toplevel_metadata,
     image_to_zarr,
-    plate_to_zarr,
+    plate_to_zarr, dataset_to_zarr,
 )
 
 HELP = """Export data in zarr format.
@@ -218,7 +219,7 @@ class ZarrControl(BaseControl):
         export.add_argument(
             "--max_workers",
             default=None,
-            help="Maximum number of workers (only for use with bioformats2raw)",
+            help="Maximum number of workers",
         )
         export.add_argument(
             "object",
@@ -257,10 +258,13 @@ class ZarrControl(BaseControl):
             if args.bf:
                 self._bf_export(image, args)
             else:
-                image_to_zarr(image, args)
+                image_to_zarr(image, args.output, args.cache_numpy)
         elif isinstance(args.object, PlateI):
             plate = self._lookup(self.gateway, "Plate", args.object.id)
             plate_to_zarr(plate, args)
+        elif isinstance(args.object, DatasetI):
+            dataset = self._lookup(self.gateway, "Dataset", args.object.id)
+            dataset_to_zarr(dataset, args)
 
     def _lookup(
         self, gateway: BlitzGateway, otype: str, oid: int

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -16,8 +16,9 @@ from .masks import MASK_DTYPE_SIZE, image_shapes_to_zarr, plate_shapes_to_zarr
 from .raw_pixels import (
     add_omero_metadata,
     add_toplevel_metadata,
+    dataset_to_zarr,
     image_to_zarr,
-    plate_to_zarr, dataset_to_zarr,
+    plate_to_zarr,
 )
 
 HELP = """Export data in zarr format.


### PR DESCRIPTION
Attempt to add 'export dataset' functionality. Exports all images of a dataset into a directory with the dataset id as name. Export of the images happens in parallel using dask.
But something's not quite right. After running for a while you'll get a out of Java heap space error on the server side:
```
...
File "/home/dlindner/miniconda3/lib/python3.9/site-packages/omero_api_RawPixelsStore_ice.py", line 1199, in getPlane
    return _M_omero.api.RawPixelsStore._op_getPlane.invoke(self, ((z, c, t), _ctx))
omero.InternalException: exception ::omero::InternalException
{
    serverStackTrace = ome.conditions.InternalException:  Wrapped Exception: (java.lang.OutOfMemoryError):
Java heap space
        at loci.formats.tiff.TiffParser.getSamples(TiffParser.java:1030)
```
Is that an error on the client side (session not closed, etc.) or a server side issue? Any ideas @sbesson @joshmoore ?
