### PR TITLE
Export dataset

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr
+known_third_party = dask,numpy,ome_zarr,omero,omero_model_DatasetI,omero_zarr,setuptools,skimage,zarr

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, List
 from omero.cli import CLI, BaseControl, Parser, ProxyStringType
 from omero.gateway import BlitzGateway, BlitzObjectWrapper
 from omero.model import ImageI, PlateI
+from omero_model_DatasetI import DatasetI
 from zarr.hierarchy import open_group
 from zarr.storage import FSStore
 
@@ -16,7 +17,7 @@ from .raw_pixels import (
     add_omero_metadata,
     add_toplevel_metadata,
     image_to_zarr,
-    plate_to_zarr,
+    plate_to_zarr, dataset_to_zarr,
 )
 
 HELP = """Export data in zarr format.
@@ -218,7 +219,7 @@ class ZarrControl(BaseControl):
         export.add_argument(
             "--max_workers",
             default=None,
-            help="Maximum number of workers (only for use with bioformats2raw)",
+            help="Maximum number of workers",
         )
         export.add_argument(
             "object",
@@ -257,10 +258,13 @@ class ZarrControl(BaseControl):
             if args.bf:
                 self._bf_export(image, args)
             else:
-                image_to_zarr(image, args)
+                image_to_zarr(image, args.output, args.cache_numpy)
         elif isinstance(args.object, PlateI):
             plate = self._lookup(self.gateway, "Plate", args.object.id)
             plate_to_zarr(plate, args)
+        elif isinstance(args.object, DatasetI):
+            dataset = self._lookup(self.gateway, "Dataset", args.object.id)
+            dataset_to_zarr(dataset, args)
 
     def _lookup(
         self, gateway: BlitzGateway, otype: str, oid: int

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -16,8 +16,9 @@ from .masks import MASK_DTYPE_SIZE, image_shapes_to_zarr, plate_shapes_to_zarr
 from .raw_pixels import (
     add_omero_metadata,
     add_toplevel_metadata,
+    dataset_to_zarr,
     image_to_zarr,
-    plate_to_zarr, dataset_to_zarr,
+    plate_to_zarr,
 )
 
 HELP = """Export data in zarr format.

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -79,6 +79,8 @@ def dataset_to_zarr(
             name = f"{name}_{image.id}"
         collection[name] = {}
         img_root = root.create_group(name)
+        # Update attrs as we go, don't wait for completion
+        root.attrs["collection"] = {"images": collection}
         jobs.append(
             dask.delayed(image_to_zarr_threadsafe)(
                 dataset._conn.c, image.getId(), img_root, cache_dir
@@ -89,7 +91,6 @@ def dataset_to_zarr(
             dask.delayed()(jobs).compute()
     else:
         dask.delayed()(jobs).compute()
-    root.attrs["collection"] = collection
 
 
 def add_image(


### PR DESCRIPTION
This fixes the collection metadata to use `images` key: it should be `"collection": {"images": {} }`.

Also, this updates the metadata attrs as each image is added to the queue at the start.
This way, if the export fails at some point, you still have the collection metadata.