### PR TITLE
Also define --output option at the subcommand parser for usability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="The Open Microscopy Team",
     author_email="",
     python_requires=">=3",
-    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.2.1.dev0"],
+    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.2.0"],
     long_description=long_description,
     keywords=["OMERO.CLI", "plugin"],
     url="https://github.com/ome/omero-cli-zarr/",

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -226,6 +226,11 @@ class ZarrControl(BaseControl):
             help="The Image to export.",
         )
 
+        for subcommand in (polygons, masks, export):
+            subcommand.add_argument(
+                "--output", type=str, default="", help="The output directory"
+            )
+
     @gateway_required
     def masks(self, args: argparse.Namespace) -> None:
         """Export masks on the Image as zarr files."""


### PR DESCRIPTION
Addresses some usability feedback reported @pwalczysko and @dominikl. The `--output` argument is currently defined at the level of the `zarr` command parser making it hard to discover via the command help or remember.

4a04e23 proposes to specify the argument explicitly for each command. From the usage perspective, this means

```
omero zarr export --help
```

should also list the `--output OUTPUT`  argument. In terms of functional testing, the following command should work

```
omero zarr export Image:1 --output /tmp 
```

The previous behavior is conserved so that existing usage does not break i.e. 

```
omero zarr --output /tmp export Image:1
```

In the unlikely case where `--output` is specified twice, local testing suggests the last specified option takes precedence