### PR TITLE
Axes v0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="The Open Microscopy Team",
     author_email="",
     python_requires=">=3",
-    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.2.0"],
+    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.3a1"],
     long_description=long_description,
     keywords=["OMERO.CLI", "plugin"],
     url="https://github.com/ome/omero-cli-zarr/",

--- a/src/omero_zarr/__init__.py
+++ b/src/omero_zarr/__init__.py
@@ -1,6 +1,6 @@
 from ._version import version as __version__
 
-ngff_version = "0.3"
+ngff_version = "0.4"
 
 __all__ = [
     "__version__",

--- a/src/omero_zarr/__init__.py
+++ b/src/omero_zarr/__init__.py
@@ -1,6 +1,8 @@
+from ome_zarr.format import CurrentFormat
+
 from ._version import version as __version__
 
-ngff_version = "0.4"
+ngff_version = CurrentFormat().version
 
 __all__ = [
     "__version__",

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -303,7 +303,7 @@ class MaskSaver:
             ignored_dimensions,
             check_overlaps=True,
         )
-        # For v0.3 ngff we want to reduce the number of dimensions to
+        # For v0.3+ ngff we want to reduce the number of dimensions to
         # match the dims of the Image.
         dims_to_squeeze = []
         axes = []
@@ -326,7 +326,7 @@ class MaskSaver:
         image_label_colors: List[JSONDict] = []
         label_properties: List[JSONDict] = []
         image_label = {
-            "version": "0.3",
+            "version": "0.4",
             "colors": image_label_colors,
             "properties": label_properties,
             "source": {"image": source_image_link},

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -18,6 +18,7 @@ from omero.rtypes import unwrap
 from skimage.draw import polygon as sk_polygon
 from zarr.hierarchy import open_group
 
+from . import ngff_version as VERSION
 from .util import marshal_axes, open_store, print_status
 
 # Mapping of dimension names to axes in the Zarr
@@ -327,7 +328,7 @@ class MaskSaver:
         image_label_colors: List[JSONDict] = []
         label_properties: List[JSONDict] = []
         image_label = {
-            "version": "0.4",
+            "version": VERSION,
             "colors": image_label_colors,
             "properties": label_properties,
             "source": {"image": source_image_link},

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -19,7 +19,7 @@ from skimage.draw import polygon as sk_polygon
 from zarr.hierarchy import open_group
 
 from . import ngff_version as VERSION
-from .util import marshal_axes, open_store, print_status
+from .util import marshal_axes, marshal_transformations, open_store, print_status
 
 # Mapping of dimension names to axes in the Zarr
 DIMENSION_ORDER: Dict[str, int] = {
@@ -306,7 +306,8 @@ class MaskSaver:
             check_overlaps=True,
         )
 
-        metadata = marshal_axes(self.image, levels=1)
+        axes = marshal_axes(self.image)
+        transformations = marshal_transformations(self.image, levels=1)
 
         # For v0.3+ ngff we want to reduce the number of dimensions to
         # match the dims of the Image.
@@ -321,7 +322,7 @@ class MaskSaver:
         pyramid_grp = out_labels.require_group(name)
 
         write_multiscale(
-            label_pyramid, pyramid_grp, **metadata
+            label_pyramid, pyramid_grp, axes=axes, transformations=transformations
         )  # TODO: dtype, chunks, overwite
 
         # Specify and store metadata

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -7,7 +7,11 @@ import numpy
 import numpy as np
 import omero.clients  # noqa
 import omero.gateway  # required to allow 'from omero_zarr import raw_pixels'
-from ome_zarr.writer import write_multiscales_metadata, write_plate_metadata
+from ome_zarr.writer import (
+    write_multiscales_metadata,
+    write_plate_metadata,
+    write_well_metadata,
+)
 from omero.rtypes import unwrap
 from skimage.transform import resize
 from zarr.hierarchy import Array, Group, open_group
@@ -256,7 +260,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
                 add_image(img, field_group, cache_dir=cache_dir)
                 add_omero_metadata(field_group, img)
                 # Update Well metadata after each image
-                col_group.attrs["well"] = {"images": fields, "version": VERSION}
+                write_well_metadata(col_group, fields)
                 max_fields = max(max_fields, field + 1)
             print_status(int(t0), int(time.time()), count, total)
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -33,7 +33,7 @@ def image_to_zarr(image: omero.gateway.ImageWrapper, args: argparse.Namespace) -
 
 def add_image(
     image: omero.gateway.ImageWrapper, parent: Group, cache_dir: Optional[str] = None
-) -> Tuple[int, List[str]]:
+) -> Tuple[int, List[Dict[str, Any]]]:
     """Adds an OMERO image pixel data as array to the given parent zarr group.
     Optionally caches the pixel data in the given cache_dir directory.
     Returns the number of resolution levels generated for the image.
@@ -103,7 +103,7 @@ def add_raw_image(
     level_count: int,
     cache_dir: Optional[str] = None,
     cache_file_name_func: Callable[[int, int, int], str] = None,
-) -> Tuple[int, List[str]]:
+) -> Tuple[int, List[Dict[str, Any]]]:
     """Adds the raw image pixel data as array to the given parent zarr group.
     Optionally caches the pixel data in the given cache_dir directory.
     Returns the number of resolution levels generated for the image.
@@ -123,11 +123,11 @@ def add_raw_image(
     dims = [dim for dim in [size_t, size_c, size_z] if dim != 1]
     axes = []
     if size_t > 1:
-        axes.append("t")
+        axes.append({"name": "t", "type": "time"})
     if size_c > 1:
-        axes.append("c")
+        axes.append({"name": "c", "type": "channel"})
     if size_z > 1:
-        axes.append("z")
+        axes.append({"name": "z", "type": "space"})
 
     field_groups: List[Array] = []
     for t in range(size_t):
@@ -179,7 +179,8 @@ def add_raw_image(
                             preserve_range=True,
                             anti_aliasing=False,
                         ).astype(plane.dtype)
-    return (level_count, axes + ["y", "x"])
+    axes = axes + [{"name": "y", "type": "space"}, {"name": "x", "type": "space"}]
+    return (level_count, axes)
 
 
 def marshal_acquisition(acquisition: omero.gateway._PlateAcquisitionWrapper) -> Dict:
@@ -275,7 +276,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
 
 def add_multiscales_metadata(
     zarr_root: Group,
-    axes: List[str],
+    axes: List[Dict[str, str]],
     resolutions: int = 1,
 ) -> None:
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -18,7 +18,7 @@ from zarr.hierarchy import Array, Group, open_group
 
 from . import __version__
 from . import ngff_version as VERSION
-from .util import marshal_axes, open_store, print_status
+from .util import marshal_axes, marshal_transformations, open_store, print_status
 
 
 def image_to_zarr(image: omero.gateway.ImageWrapper, args: argparse.Namespace) -> None:
@@ -95,11 +95,14 @@ def add_image(
         cache_file_name_func=get_cache_filename,
     )
 
-    metadata = marshal_axes(image, len(paths))
+    axes = marshal_axes(image)
+    transformations = marshal_transformations(image, len(paths))
 
-    write_multiscales_metadata(parent, paths, **metadata)
+    write_multiscales_metadata(
+        parent, paths, axes=axes, transformations=transformations
+    )
 
-    return (level_count, metadata["axes"])
+    return (level_count, axes)
 
 
 def add_raw_image(

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -282,7 +282,7 @@ def add_multiscales_metadata(
 
     multiscales = [
         {
-            "version": "0.3",
+            "version": "0.4",
             "datasets": [{"path": str(r)} for r in range(resolutions)],
             "axes": axes,
         }

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -24,8 +24,7 @@ def image_to_zarr(image: omero.gateway.ImageWrapper, args: argparse.Namespace) -
     print(f"Exporting to {name} ({VERSION})")
     store = open_store(name)
     root = open_group(store)
-    n_levels, axes = add_image(image, root, cache_dir=cache_dir)
-    add_multiscales_metadata(root, axes, n_levels)
+    add_image(image, root, cache_dir=cache_dir)
     add_omero_metadata(root, image)
     add_toplevel_metadata(root)
     print("Finished.")
@@ -53,7 +52,7 @@ def add_image(
     pix_size_x = image.getPixelSizeX(units=True)
     pix_size_y = image.getPixelSizeY(units=True)
     pix_size_z = image.getPixelSizeZ(units=True)
-    # All OMERO units.toLowerCase() are valid UDUNITS-2 and therefore NGFF spec
+    # All OMERO units.lower() are valid UDUNITS-2 and therefore NGFF spec
     if pix_size_x is not None:
         pixel_sizes["x"] = {
             "units": str(pix_size_x.getUnit()).lower(),
@@ -125,6 +124,8 @@ def add_image(
         cache_dir=cache_dir,
         cache_file_name_func=get_cache_filename,
     )
+
+    add_multiscales_metadata(parent, axes, level_count)
 
     return (level_count, axes)
 
@@ -287,8 +288,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
                 row_group = root.require_group(row)
                 col_group = row_group.require_group(col)
                 field_group = col_group.require_group(field_name)
-                n_levels, axes = add_image(img, field_group, cache_dir=cache_dir)
-                add_multiscales_metadata(field_group, axes, n_levels)
+                add_image(img, field_group, cache_dir=cache_dir)
                 add_omero_metadata(field_group, img)
                 # Update Well metadata after each image
                 col_group.attrs["well"] = {"images": fields, "version": VERSION}

--- a/src/omero_zarr/util.py
+++ b/src/omero_zarr/util.py
@@ -1,5 +1,7 @@
 import time
+from typing import Dict, List
 
+from omero.gateway import ImageWrapper
 from zarr.storage import FSStore
 
 
@@ -33,3 +35,69 @@ def open_store(name: str) -> FSStore:
         normalize_keys=False,
         mode="w",
     )
+
+
+def marshal_axes(
+    image: ImageWrapper, levels: int = 1, multiscales_zoom: float = 2.0
+) -> Dict[str, List]:
+    # Prepare axes and transformations info...
+    size_c = image.getSizeC()
+    size_z = image.getSizeZ()
+    size_t = image.getSizeT()
+    pixel_sizes = {}
+    pix_size_x = image.getPixelSizeX(units=True)
+    pix_size_y = image.getPixelSizeY(units=True)
+    pix_size_z = image.getPixelSizeZ(units=True)
+    # All OMERO units.lower() are valid UDUNITS-2 and therefore NGFF spec
+    if pix_size_x is not None:
+        pixel_sizes["x"] = {
+            "units": str(pix_size_x.getUnit()).lower(),
+            "value": pix_size_x.getValue(),
+        }
+    if pix_size_y is not None:
+        pixel_sizes["y"] = {
+            "units": str(pix_size_y.getUnit()).lower(),
+            "value": pix_size_y.getValue(),
+        }
+    if pix_size_z is not None:
+        pixel_sizes["z"] = {
+            "units": str(pix_size_z.getUnit()).lower(),
+            "value": pix_size_z.getValue(),
+        }
+
+    axes = []
+    if size_t > 1:
+        axes.append({"name": "t", "type": "time"})
+    if size_c > 1:
+        axes.append({"name": "c", "type": "channel"})
+    if size_z > 1:
+        axes.append({"name": "z", "type": "space"})
+        if pixel_sizes and "z" in pixel_sizes:
+            axes[-1]["units"] = pixel_sizes["z"]["units"]
+    # last 2 dimensions are always y and x
+    for dim in ("y", "x"):
+        axes.append({"name": dim, "type": "space"})
+        if pixel_sizes and dim in pixel_sizes:
+            axes[-1]["units"] = pixel_sizes[dim]["units"]
+
+    # Each path needs a transformations list...
+    transformations = []
+    zooms = {"x": 1.0, "y": 1.0, "z": 1.0}
+    for level in range(levels):
+        # {"type": "scale", "scale": [2.0, 2.0, 2.0], "axisIndices": [2, 3, 4]}
+        scales = []
+        axisIndices = []
+        for index, axis in enumerate(axes):
+            if axis["name"] in pixel_sizes:
+                scales.append(zooms[axis["name"]] * pixel_sizes[axis["name"]]["value"])
+                axisIndices.append(index)
+        # ...with a single 'scale' transformation each
+        if len(scales) > 0:
+            transformations.append(
+                [{"type": "scale", "scale": scales, "axisIndices": axisIndices}]
+            )
+        # NB we rescale X and Y for each level, but not Z
+        zooms["x"] = zooms["x"] * multiscales_zoom
+        zooms["y"] = zooms["y"] * multiscales_zoom
+
+    return {"axes": axes, "transformations": transformations}


### PR DESCRIPTION
Starting to implement Axes and Transformations (see https://github.com/ome/ngff/pull/57).
cc @constantinpape 

This requires  https://pypi.org/project/ome-zarr/0.3a1/ for mask writing and new HCS metadata (row/column Indexes).

To test:
```
$ omero zarr export Image:6001240     # /6001240.zarr/.zattrs  should have new axes (see below)
$ omero zarr masks Image:6001240      # /6001240.zarr/labels/0/.zattrs should also have new axes

$ omero zarr export Plate:1234           # 1234.zarr/.zattrs each 'well' should have rowIndex and columnIndex

```

Some data exported with this PR can be viewed with vizarr:
https://deploy-preview-139--vizarr.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.4/2022-01-05/idr0062/6001240.zarr (with PR at https://github.com/hms-dbmi/vizarr/pull/139)

Plate data: https://minio-dev.openmicroscopy.org/idr/v0.4/2022-01-24/plates/idr0004/1752.zarr

Exported NGFF includes:
 - axes - eg. at https://minio-dev.openmicroscopy.org/idr/v0.4/2022-01-05/idr0062/6001240.zarr/.zattrs :
```
    "axes": [
                {
                    "name": "c",
                    "type": "channel"
                },
                {
                    "name": "z",
                    "type": "space",
                    "units": "micrometer"
                },
                {
                    "name": "y",
                    "type": "space",
                    "units": "micrometer"
                },
                {
                    "name": "x",
                    "type": "space",
                    "units": "micrometer"
                }
            ]
```
and each `dataset` has transformations. E.g. czyx image is scaled along axis `z, y, x` or `[1, 2, 3]`:
NB: this format is still being discussed at https://github.com/ome/ngff/pull/57#pullrequestreview-836379663
```
                  "transformations": [
                        {
                            "axisIndices": [
                                1,
                                2,
                                3
                            ],
                            "scale": [
                                0.5002025531914894,
                                0.3603981534640209,
                                0.3603981534640209
                            ],
                            "type": "scale"
                        }
                    ]
```