### PR TITLE
Scale dict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="The Open Microscopy Team",
     author_email="",
     python_requires=">=3",
-    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.3a1"],
+    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.3a2"],
     long_description=long_description,
     keywords=["OMERO.CLI", "plugin"],
     url="https://github.com/ome/omero-cli-zarr/",

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -307,7 +307,6 @@ class MaskSaver:
         )
 
         axes = marshal_axes(self.image)
-        transformations = marshal_transformations(self.image, levels=1)
 
         # For v0.3+ ngff we want to reduce the number of dimensions to
         # match the dims of the Image.
@@ -320,9 +319,13 @@ class MaskSaver:
         scaler = Scaler(max_layer=input_pyramid_levels)
         label_pyramid = scaler.nearest(labels)
         pyramid_grp = out_labels.require_group(name)
+        transformations = marshal_transformations(self.image, levels=len(label_pyramid))
 
         write_multiscale(
-            label_pyramid, pyramid_grp, axes=axes, transformations=transformations
+            label_pyramid,
+            pyramid_grp,
+            axes=axes,
+            coordinate_transformations=transformations,
         )  # TODO: dtype, chunks, overwite
 
         # Specify and store metadata

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -100,7 +100,7 @@ def add_image(
 
     datasets: List[Dict[Any, Any]] = [{"path": path} for path in paths]
     for dataset, transform in zip(datasets, transformations):
-        dataset["transformations"] = transform
+        dataset["coordinateTransformations"] = transform
 
     write_multiscales_metadata(parent, datasets, axes=axes)
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -98,9 +98,11 @@ def add_image(
     axes = marshal_axes(image)
     transformations = marshal_transformations(image, len(paths))
 
-    write_multiscales_metadata(
-        parent, paths, axes=axes, transformations=transformations
-    )
+    datasets: List[Dict[Any, Any]] = [{"path": path} for path in paths]
+    for dataset, transform in zip(datasets, transformations):
+        dataset["transformations"] = transform
+
+    write_multiscales_metadata(parent, datasets, axes=axes)
 
     return (level_count, axes)
 

--- a/src/omero_zarr/util.py
+++ b/src/omero_zarr/util.py
@@ -96,18 +96,18 @@ def marshal_transformations(
 
     # Each path needs a transformations list...
     transformations = []
-    zooms = {"x": 1.0, "y": 1.0, "z": 1.0}
+    zooms = {"x": 1.0, "y": 1.0, "z": 1.0, "c": 1.0, "t": 1.0}
     for level in range(levels):
-        # {"type": "scale", "scale": {"x": 0.5, "y": 0.5, "z": 0.3}
-        scales = {}
+        # {"type": "scale", "scale": [1, 1, 0.3, 0.5, 0.5]
+        scales = []
         for index, axis in enumerate(axes):
+            pixel_size = 1
             if axis["name"] in pixel_sizes:
-                svalue = zooms[axis["name"]] * pixel_sizes[axis["name"]]["value"]
-                scales[axis["name"]] = svalue
+                pixel_size = pixel_sizes[axis["name"]].get("value", 1)
+            scales.append(zooms[axis["name"]] * pixel_size)
         # ...with a single 'scale' transformation each
-        if len(scales) > 0:
-            transformations.append([{"type": "scale", "scale": scales}])
-        # NB we rescale X and Y for each level, but not Z
+        transformations.append([{"type": "scale", "scale": scales}])
+        # NB we rescale X and Y for each level, but not Z, C, T
         zooms["x"] = zooms["x"] * multiscales_zoom
         zooms["y"] = zooms["y"] * multiscales_zoom
 

--- a/src/omero_zarr/util.py
+++ b/src/omero_zarr/util.py
@@ -98,18 +98,15 @@ def marshal_transformations(
     transformations = []
     zooms = {"x": 1.0, "y": 1.0, "z": 1.0}
     for level in range(levels):
-        # {"type": "scale", "scale": [2.0, 2.0, 2.0], "axisIndices": [2, 3, 4]}
-        scales = []
-        axisIndices = []
+        # {"type": "scale", "scale": {"x": 0.5, "y": 0.5, "z": 0.3}
+        scales = {}
         for index, axis in enumerate(axes):
             if axis["name"] in pixel_sizes:
-                scales.append(zooms[axis["name"]] * pixel_sizes[axis["name"]]["value"])
-                axisIndices.append(index)
+                svalue = zooms[axis["name"]] * pixel_sizes[axis["name"]]["value"]
+                scales[axis["name"]] = svalue
         # ...with a single 'scale' transformation each
         if len(scales) > 0:
-            transformations.append(
-                [{"type": "scale", "scale": scales, "axisIndices": axisIndices}]
-            )
+            transformations.append([{"type": "scale", "scale": scales}])
         # NB we rescale X and Y for each level, but not Z
         zooms["x"] = zooms["x"] * multiscales_zoom
         zooms["y"] = zooms["y"] * multiscales_zoom


### PR DESCRIPTION
As discussed in https://github.com/ome/omero-cli-zarr/pull/93#discussion_r790864982 the API for `write_multiscales_metadata()` has changed in ome/ome-zarr-py#162 and this PR uses that new API.

Also, this now exports `scales` metadata as a list `[1, 1, 0.5, 0.3, 0.3]` instead of using `axesIndices`.