### PR TITLE
Choose smallest np.dtype that handles labels data

### DIFF
--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -539,7 +539,7 @@ class MaskSaver:
             if np.iinfo(dtype).max >= max_value:
                 new_dtype = dtype
                 break
-        LOGGER.debug("Convering labels to dtype %s" % new_dtype)
+        LOGGER.debug("Converting labels to dtype %s" % new_dtype)
         labels = labels.astype(new_dtype)
 
         return labels, fillColors, properties

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -486,7 +486,7 @@ class MaskSaver:
         # find most suitable dtype...
         labels_dtype = np.int64
         sorted_dtypes = [kv for kv in MASK_DTYPE_SIZE.items()]
-        sorted_dtypes.sort(key=lambda x:x[0])
+        sorted_dtypes.sort(key=lambda x: x[0])
         # ignore first dtype (bool)
         for int_dtype in sorted_dtypes[1:]:
             dtype = int_dtype[1]

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -491,15 +491,16 @@ class MaskSaver:
         fillColors: Dict[int, str] = {}
         properties: Dict[int, Dict] = {}
 
-        min_roi_id = min(shape.roi.id.val for mask in masks for shape in mask)
-        LOGGER.debug("Min ROI ID: %s" % min_roi_id)
+        roi_ids = [shape.roi.id.val for mask in masks for shape in mask]
+        sorted_roi_ids = list(set(roi_ids))
+        sorted_roi_ids.sort()
 
         for count, shapes in enumerate(masks):
             for shape in shapes:
                 # Using ROI ID allows stitching label from multiple images
                 # into a Plate and not creating duplicates from different iamges.
                 # All shapes will be the same value (color) for each ROI
-                shape_value = shape.roi.id.val - min_roi_id + 1
+                shape_value = sorted_roi_ids.index(shape.roi.id.val) + 1
                 properties[shape_value] = {
                     "omero:shapeId": shape.id.val,
                     "omero:roiId": shape.roi.id.val,

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -491,12 +491,15 @@ class MaskSaver:
         fillColors: Dict[int, str] = {}
         properties: Dict[int, Dict] = {}
 
+        min_roi_id = min([shape.roi.id.val for mask in masks for shape in mask])
+        LOGGER.debug("Min ROI ID: %s" % min_roi_id)
+
         for count, shapes in enumerate(masks):
             for shape in shapes:
                 # Using ROI ID allows stitching label from multiple images
                 # into a Plate and not creating duplicates from different iamges.
                 # All shapes will be the same value (color) for each ROI
-                shape_value = shape.roi.id.val
+                shape_value = shape.roi.id.val - min_roi_id + 1
                 properties[shape_value] = {
                     "omero:shapeId": shape.id.val,
                     "omero:roiId": shape.roi.id.val,
@@ -520,7 +523,7 @@ class MaskSaver:
                                 )
                             ):
                                 raise Exception(
-                                    f"Mask {shape_value} overlaps with existing labels"
+                                    f"Mask {shape.roi.id.val} overlaps with existing labels"
                                 )
                             # ADD to the array, so zeros in our binarray don't
                             # wipe out previous shapes

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -491,7 +491,7 @@ class MaskSaver:
         fillColors: Dict[int, str] = {}
         properties: Dict[int, Dict] = {}
 
-        min_roi_id = min([shape.roi.id.val for mask in masks for shape in mask])
+        min_roi_id = min(shape.roi.id.val for mask in masks for shape in mask)
         LOGGER.debug("Min ROI ID: %s" % min_roi_id)
 
         for count, shapes in enumerate(masks):

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -517,7 +517,7 @@ class MaskSaver:
                             if check_overlaps and np.any(
                                 np.logical_and(
                                     labels[
-                                        i_t, i_c, i_z, y :(y + h), x :(x + w)
+                                        i_t, i_c, i_z, y : (y + h), x : (x + w)
                                     ].astype(np.bool),
                                     binim_yx,
                                 )
@@ -528,7 +528,7 @@ class MaskSaver:
                                 )
                             # ADD to the array, so zeros in our binarray don't
                             # wipe out previous shapes
-                            labels[i_t, i_c, i_z, y :(y + h), x :(x + w)] += (
+                            labels[i_t, i_c, i_z, y : (y + h), x : (x + w)] += (
                                 binim_yx * shape_value
                             )
         max_value = labels.max()

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -517,17 +517,18 @@ class MaskSaver:
                             if check_overlaps and np.any(
                                 np.logical_and(
                                     labels[
-                                        i_t, i_c, i_z, y : (y + h), x : (x + w)
+                                        i_t, i_c, i_z, y :(y + h), x :(x + w)
                                     ].astype(np.bool),
                                     binim_yx,
                                 )
                             ):
                                 raise Exception(
-                                    f"Mask {shape.roi.id.val} overlaps with existing labels"
+                                    f"Mask {shape.roi.id.val} overlaps "
+                                    "with existing labels"
                                 )
                             # ADD to the array, so zeros in our binarray don't
                             # wipe out previous shapes
-                            labels[i_t, i_c, i_z, y : (y + h), x : (x + w)] += (
+                            labels[i_t, i_c, i_z, y :(y + h), x :(x + w)] += (
                                 binim_yx * shape_value
                             )
         max_value = labels.max()


### PR DESCRIPTION
Fixes #115

This PR
 - Uses the ROI ID, subtracting the smallest ROI ID, as the mask value
 - Uses the smallest `np.dtype` that is required for the maximum mask value.

To test: export labels and check dtype (was previously `"<i8"`):
```
$ omero zarr export Image:6001240
$ omero zarr masks Image:6001240

$ cat 6001240.zarr/labels/0/0/.zarray | grep dtype
    "dtype": "<i2",
```

Napari should still show masks correctly, with omero IDs shown when mousing over shapes:

```$ napari --plugin napari-ome-zarr 6001240.zarr```

Mousing over label at bottom-left:

<img width="986" alt="Screenshot 2022-05-27 at 12 41 35" src="https://user-images.githubusercontent.com/900055/170692877-31734c73-2a0c-4b87-89ae-3f6220c2f3a1.png">

Check shape ID:
https://idr.openmicroscopy.org/iviewer/?shape=1664664