### PR TITLE
Allow to use bioformats2raw to export HCS data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="The Open Microscopy Team",
     author_email="",
     python_requires=">=3",
-    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.3.1.dev0"],
+    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.3.0"],
     long_description=long_description,
     keywords=["OMERO.CLI", "plugin"],
     url="https://github.com/ome/omero-cli-zarr/",

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -323,25 +323,29 @@ class ZarrControl(BaseControl):
             self.ctx.die(110, f"No such {otype}: {oid}")
         return obj
 
-    def _get_first_imported_filepath(self, obj: BlitzObjectWrapper,path_type: str):
-        if obj.OMERO_CLASS == "Plate":
-            for well in obj.listChildren():
-                for ws in well.listChildren():
-                    return _get_first_imported_path(ws.getImage(), path_type)
-        return obj.getImportedImageFilePaths()[path_type][0]
-
     def _bf_export(self, obj: BlitzObjectWrapper, args: argparse.Namespace) -> None:
+
+        def _get_first_image(obj):
+            if obj.OMERO_CLASS == "Plate":
+                for well in obj.listChildren():
+                    for ws in well.listChildren():
+                        return ws.getImage()
+            else:
+                return obj
+
         if args.bfpath:
             abs_path = Path(args.bfpath)
-        elif obj.getInplaceImport():
-            p = _get_first_imported_filepath(obj, "client_paths")
-            abs_path = Path("/") / Path(p)
         else:
-            if self.client is None:
-                raise Exception("This cannot happen")  # mypy is confused
-            prx, desc = self.client.getManagedRepository(description=True)
-            p = _get_first_imported_filepath(obj, "server_paths")
-            abs_path = Path(desc._path._val) / Path(desc._name._val) / Path(p)
+            first_image = _get_first_image(obj)
+            if first_image.getInplaceImport():
+                p = first_image.getImportedImageFilePaths()["client_paths"][0]
+                abs_path = Path("/") / Path(p)
+            else:
+                if self.client is None:
+                    raise Exception("This cannot happen")  # mypy is confused
+                prx, desc = self.client.getManagedRepository(description=True)
+                p = first_image.getImportedImageFilePaths()["server_paths"][0]
+                abs_path = Path(desc._path._val) / Path(desc._name._val) / Path(p)
         temp_target = (Path(args.output) or Path.cwd()) / f"{obj.id}.tmp"
         zarr_target = (Path(args.output) or Path.cwd()) / f"{obj.id}.zarr"
 

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -324,7 +324,6 @@ class ZarrControl(BaseControl):
         return obj
 
     def _bf_export(self, obj: BlitzObjectWrapper, args: argparse.Namespace) -> None:
-
         def _get_first_image(obj):
             if obj.OMERO_CLASS == "Plate":
                 for well in obj.listChildren():

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Callable, List
 
 from omero.cli import CLI, BaseControl, Parser, ProxyStringType
-from omero.gateway import BlitzGateway, BlitzObjectWrapper
+from omero.gateway import BlitzGateway, BlitzObjectWrapper, ImageWrapper
 from omero.model import ImageI, PlateI
 from zarr.hierarchy import open_group
 from zarr.storage import FSStore
@@ -324,7 +324,7 @@ class ZarrControl(BaseControl):
         return obj
 
     def _bf_export(self, obj: BlitzObjectWrapper, args: argparse.Namespace) -> None:
-        def _get_first_image(obj):
+        def _get_first_image(obj: BlitzObjectWrapper) -> ImageWrapper:
             if obj.OMERO_CLASS == "Plate":
                 for well in obj.listChildren():
                     for ws in well.listChildren():
@@ -393,7 +393,7 @@ class ZarrControl(BaseControl):
         if obj.OMERO_CLASS == "Image":
             # Add OMERO metadata
             store = FSStore(
-                str(image_target.resolve()),
+                str(zarr_target.resolve()),
                 auto_mkdir=False,
                 normalize_keys=False,
                 mode="w",

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -294,7 +294,7 @@ def plate_to_zarr(
 def add_omero_metadata(zarr_root: Group, image: omero.gateway.ImageWrapper) -> None:
 
     image_data = {
-        "id": 1,
+        "id": image.getId(),
         "channels": [channelMarshal(c) for c in image.getChannels()],
         "rdefs": {
             "model": (image.isGreyscaleRenderingModel() and "greyscale" or "color"),

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -210,7 +210,9 @@ def marshal_acquisition(acquisition: omero.gateway._PlateAcquisitionWrapper) -> 
     return acq
 
 
-def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace, write_binary=True) -> None:
+def plate_to_zarr(
+    plate: omero.gateway._PlateWrapper, args: argparse.Namespace, write_binary=True
+) -> None:
     """
     Exports a plate to a zarr file using the hierarchy discussed here ('Option 3'):
     https://github.com/ome/omero-ms-zarr/issues/73#issuecomment-706770955

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -211,7 +211,9 @@ def marshal_acquisition(acquisition: omero.gateway._PlateAcquisitionWrapper) -> 
 
 
 def plate_to_zarr(
-    plate: omero.gateway._PlateWrapper, args: argparse.Namespace, write_binary=True
+    plate: omero.gateway._PlateWrapper,
+    args: argparse.Namespace,
+    write_binary: Optional[bool] = True,
 ) -> None:
     """
     Exports a plate to a zarr file using the hierarchy discussed here ('Option 3'):


### PR DESCRIPTION
Fixes #85 

Makes the minimal set of changes allowing to re-use the existing infrastructure with bioformats2raw 0.5.0rc2 to generate OME-NGFF including:
- bioformats2raw writing OME-NGFF HCS as defined by the OME-NGFF 0.4 specification, including the bioformat2raw layout with the OME metadata defined https://github.com/ome/ngff/pull/112
- an extra step appending the OMERO metadata to each field of view

To do:

- [ ] current test use `--bfpath` as the order of `getImportedImageFilePaths` is not guaranteed and cannot be used directly with `bioformats2raw`
- [ ] review `plate_to_zarr` which is updated to allow overwriting the metadata only without rewriting the logic in a separate function.