### PR TITLE
add --allow_overlaps arg to cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,10 +59,10 @@ To export images via bioformats2raw we use the ```--bf``` flag::
     $ omero zarr --output /home/user/zarr_files export 1 --bf
     Image exported to /home/user/zarr_files/2chZT.lsm
 
-Masks
-^^^^^
+Masks and Polygons
+^^^^^^^^^^^^^^^^^^
 
-To export Masks for an Image or Plate::
+To export Masks or Polygons for an Image or Plate, use the `masks` or `polygons` command::
 
     # Saved under 1.zarr/labels/0 - 1.zarr/ must already exist
     $ omero zarr masks Image:1
@@ -78,12 +78,16 @@ To export Masks for an Image or Plate::
     # e.g. Export to 1.zarr/labels/A
     $ omero zarr masks Image:1 --label-name=A
 
-The default behaviour is to export all masks on the Image to a single 5D
-"labeled" zarr array, with a different value for each mask Shape.
-An exception will be thrown if any of the masks overlap.
+    # Allow overlapping masks or polygons (overlap will be sum of each label)
+    $ omero zarr polygons Image:1 --allow_overlaps
 
-To handle overlapping masks, split masks into non-overlapping zarr groups
-using a "label-map" which is a csv file of that specifies the name of
+The default behaviour is to export all masks or polygons on the Image to a single 5D
+"labeled" zarr array, with a different value for each Shape.
+An exception will be thrown if any of the masks overlap, unless the `--allow_overlaps`
+flag is used as above.
+
+An alternative to handle overlapping masks is to split masks into non-overlapping zarr
+groups using a "label-map" which is a csv file that specifies the name of
 the zarr group for each ROI on the Image. Columns are ID, NAME, ROI_ID.
 
 For example, to create a group from the `textValue` of each Shape,

--- a/README.rst
+++ b/README.rst
@@ -78,13 +78,13 @@ To export Masks or Polygons for an Image or Plate, use the `masks` or `polygons`
     # e.g. Export to 1.zarr/labels/A
     $ omero zarr masks Image:1 --label-name=A
 
-    # Allow overlapping masks or polygons (overlap will be sum of each label)
-    $ omero zarr polygons Image:1 --allow_overlaps
+    # Allow overlapping masks or polygons (overlap will be maximum value of the dtype)
+    $ omero zarr polygons Image:1 --overlaps=dtype_max
 
 The default behaviour is to export all masks or polygons on the Image to a single 5D
 "labeled" zarr array, with a different value for each Shape.
-An exception will be thrown if any of the masks overlap, unless the `--allow_overlaps`
-flag is used as above.
+An exception will be thrown if any of the masks overlap, unless the `--overlaps`
+option is used as above.
 
 An alternative to handle overlapping masks is to split masks into non-overlapping zarr
 groups using a "label-map" which is a csv file that specifies the name of

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -11,7 +11,12 @@ from omero.model import ImageI, PlateI
 from zarr.hierarchy import open_group
 from zarr.storage import FSStore
 
-from .masks import MASK_DTYPE_SIZE, image_shapes_to_zarr, plate_shapes_to_zarr
+from .masks import (
+    MASK_DTYPE_SIZE,
+    MaskSaver,
+    image_shapes_to_zarr,
+    plate_shapes_to_zarr,
+)
 from .raw_pixels import (
     add_omero_metadata,
     add_toplevel_metadata,
@@ -276,7 +281,8 @@ class ZarrControl(BaseControl):
             subcommand.add_argument(
                 "--overlaps",
                 type=str,
-                choices=["dtype_max"],
+                default=MaskSaver.OVERLAPS[0],
+                choices=MaskSaver.OVERLAPS,
                 help="To allow overlapping shapes, use 'dtype_max':"
                 " All overlapping regions will be set to the"
                 " max value for the dtype",

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -276,7 +276,8 @@ class ZarrControl(BaseControl):
             subcommand.add_argument(
                 "--allow_overlaps",
                 action="store_true",
-                help="Allow overlapping shapes. Output labels will add values in overlapping regions",
+                help="Allow overlapping shapes."
+                " Output labels will add values in overlapping regions",
             )
 
     @gateway_required

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -274,10 +274,10 @@ class ZarrControl(BaseControl):
             )
         for subcommand in (polygons, masks):
             subcommand.add_argument(
-                "--allow_overlaps",
-                action="store_true",
-                help="Allow overlapping shapes. All overlapping regions"
-                " will be set to the max value for the dtype",
+                "--overlaps", type=str, choices=["dtype_max"],
+                help="To allow overlapping shapes, use 'dtype_max':"
+                " All overlapping regions will be set to the"
+                " max value for the dtype",
             )
 
     @gateway_required

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -274,7 +274,9 @@ class ZarrControl(BaseControl):
             )
         for subcommand in (polygons, masks):
             subcommand.add_argument(
-                "--overlaps", type=str, choices=["dtype_max"],
+                "--overlaps",
+                type=str,
+                choices=["dtype_max"],
                 help="To allow overlapping shapes, use 'dtype_max':"
                 " All overlapping regions will be set to the"
                 " max value for the dtype",

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -274,8 +274,9 @@ class ZarrControl(BaseControl):
             )
         for subcommand in (polygons, masks):
             subcommand.add_argument(
-                "--allow_overlaps", action="store_true",
-                help="Allow overlapping shapes. Output labels will add values in overlapping regions"
+                "--allow_overlaps",
+                action="store_true",
+                help="Allow overlapping shapes. Output labels will add values in overlapping regions",
             )
 
     @gateway_required

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -276,8 +276,8 @@ class ZarrControl(BaseControl):
             subcommand.add_argument(
                 "--allow_overlaps",
                 action="store_true",
-                help="Allow overlapping shapes."
-                " Output labels will add values in overlapping regions",
+                help="Allow overlapping shapes. All overlapping regions"
+                " will be set to the max value for the dtype",
             )
 
     @gateway_required

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -272,6 +272,11 @@ class ZarrControl(BaseControl):
             subcommand.add_argument(
                 "--output", type=str, default="", help="The output directory"
             )
+        for subcommand in (polygons, masks):
+            subcommand.add_argument(
+                "--allow_overlaps", action="store_true",
+                help="Allow overlapping shapes. Output labels will add values in overlapping regions"
+            )
 
     @gateway_required
     def masks(self, args: argparse.Namespace) -> None:

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -65,8 +65,13 @@ def plate_shapes_to_zarr(
 
     dtype = MASK_DTYPE_SIZE[int(args.label_bits)]
     saver = MaskSaver(
-        plate, None, dtype, args.label_path, args.style, args.source_image,
-        check_overlaps
+        plate,
+        None,
+        dtype,
+        args.label_path,
+        args.style,
+        args.source_image,
+        check_overlaps,
     )
 
     count = 0

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -60,9 +60,13 @@ def plate_shapes_to_zarr(
     n_fields = plate.getNumberOfFields()
     total = n_rows * n_cols * (n_fields[1] - n_fields[0] + 1)
 
+    # If overlaps isn't 'dtype_max', an exception is thrown if any overlaps exist
+    check_overlaps = args.overlaps != "dtype_max"
+
     dtype = MASK_DTYPE_SIZE[int(args.label_bits)]
     saver = MaskSaver(
-        plate, None, dtype, args.label_path, args.style, args.source_image
+        plate, None, dtype, args.label_path, args.style, args.source_image,
+        check_overlaps
     )
 
     count = 0
@@ -152,7 +156,8 @@ def image_shapes_to_zarr(
         print("Boolean type makes no sense for labeled. Using 64")
         dtype = MASK_DTYPE_SIZE[64]
 
-    check_overlaps = not args.allow_overlaps
+    # If overlaps isn't 'dtype_max', an exception is thrown if any overlaps exist
+    check_overlaps = args.overlaps != "dtype_max"
     if masks:
         saver = MaskSaver(
             None,

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -190,7 +190,7 @@ class MaskSaver:
     masks to zarr groups/arrays.
     """
 
-    OVERLAPS = ["error", "dtype_max"]
+    OVERLAPS = ("error", "dtype_max")
 
     def __init__(
         self,

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -522,9 +522,9 @@ class MaskSaver:
                             ignored_dimensions, "Z", z, size_z
                         ):
                             overlap = np.logical_and(
-                                labels[
-                                    i_t, i_c, i_z, y : (y + h), x : (x + w)
-                                ].astype(np.bool),
+                                labels[i_t, i_c, i_z, y : (y + h), x : (x + w)].astype(
+                                    np.bool
+                                ),
                                 binim_yx,
                             )
                             # ADD to the array, so zeros in our binarray don't
@@ -542,5 +542,6 @@ class MaskSaver:
                                 else:
                                     # set overlapping region to max(dtype)
                                     labels[i_t, i_c, i_z, y : (y + h), x : (x + w)][
-                                        overlap] = np.iinfo(labels_dtype).max
+                                        overlap
+                                    ] = np.iinfo(labels_dtype).max
         return labels, fillColors, properties

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -68,7 +68,7 @@ def plate_shapes_to_zarr(
         args.label_path,
         args.style,
         args.source_image,
-        args=args,
+        args.overlaps,
     )
 
     count = 0
@@ -166,7 +166,7 @@ def image_shapes_to_zarr(
             args.label_path,
             args.style,
             args.source_image,
-            args=args,
+            args.overlaps,
         )
 
         if args.style == "split":
@@ -200,7 +200,7 @@ class MaskSaver:
         path: str = "labels",
         style: str = "labeled",
         source: str = "..",
-        args: argparse.Namespace = None,
+        overlaps: str = "error",
     ) -> None:
         self.dtype = dtype
         self.path = path
@@ -208,10 +208,7 @@ class MaskSaver:
         self.source_image = source
         self.plate = plate
         self.plate_path = Optional[str]
-        if args is not None and args.overlaps is not None:
-            self.overlaps = args.overlaps
-        else:
-            self.overlaps = "error"
+        self.overlaps = overlaps
         if image:
             self.image = image
             self.size_t = image.getSizeT()

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -152,10 +152,16 @@ def image_shapes_to_zarr(
         print("Boolean type makes no sense for labeled. Using 64")
         dtype = MASK_DTYPE_SIZE[64]
 
-    check_overlaps = (not args.allow_overlaps)
+    check_overlaps = not args.allow_overlaps
     if masks:
         saver = MaskSaver(
-            None, image, dtype, args.label_path, args.style, args.source_image, check_overlaps
+            None,
+            image,
+            dtype,
+            args.label_path,
+            args.style,
+            args.source_image,
+            check_overlaps,
         )
 
         if args.style == "split":

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -152,9 +152,10 @@ def image_shapes_to_zarr(
         print("Boolean type makes no sense for labeled. Using 64")
         dtype = MASK_DTYPE_SIZE[64]
 
+    check_overlaps = (not args.allow_overlaps)
     if masks:
         saver = MaskSaver(
-            None, image, dtype, args.label_path, args.style, args.source_image
+            None, image, dtype, args.label_path, args.style, args.source_image, check_overlaps
         )
 
         if args.style == "split":
@@ -186,6 +187,7 @@ class MaskSaver:
         path: str = "labels",
         style: str = "labeled",
         source: str = "..",
+        check_overlaps: bool = True,
     ) -> None:
         self.dtype = dtype
         self.path = path
@@ -193,6 +195,7 @@ class MaskSaver:
         self.source_image = source
         self.plate = plate
         self.plate_path = Optional[str]
+        self.check_overlaps = check_overlaps
         if image:
             self.image = image
             self.size_t = image.getSizeT()
@@ -302,7 +305,7 @@ class MaskSaver:
             masks,
             mask_shape,
             ignored_dimensions,
-            check_overlaps=True,
+            check_overlaps=self.check_overlaps,
         )
 
         axes = marshal_axes(self.image)


### PR DESCRIPTION
Add support for `--overlaps=dtype_max` to cli for Image and Plate export of polygons and masks. Also update README with this (and mention export of polygons).
To test, using IDR: (idr0001):

```
$ omero zarr export Image:1229801
$ omero zarr polygons Image:1229801 --overlaps=dtype_max

$ napari --plugin napari-ome-zarr 1229801.zarr
```
Not tested Plate export yet, or export of `masks`.
Overlapping regions should be exported with a value of `dtype.max`.

NB: The masks for the Image above are exported as a single plane with Z index of 0. Only by scrolling to first Z-index are they visible (See screenshot)
I wonder if we can use `coordinateTransformations` to solve this?

Without the `--overlaps` arg, we get:
```
  File "/Users/wmoore/Desktop/ZARR/omero-cli-zarr/src/omero_zarr/masks.py", line 529, in masks_to_labels
    raise Exception(
Exception: Mask 632801 overlaps with existing labels
```

![Screenshot 2022-06-21 at 13 47 57](https://user-images.githubusercontent.com/900055/174803175-378c9d51-51ed-4e3d-a25c-f3e81838085d.png)

