### PR TITLE
Big images

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr
+known_third_party = dask,numpy,ome_zarr,omero,omero_zarr,setuptools,skimage,zarr

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: seed-isort-config
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]

--- a/README.rst
+++ b/README.rst
@@ -46,13 +46,12 @@ To export Images or Plates via the OMERO API::
     # Specify an output directory
     $ omero zarr --output /home/user/zarr_files export Image:1
 
-    # Cache each plane as a numpy file.npy. If connection is lost, and you need
-    # to export again, we can use these instead of downloading again
-    $ omero zarr --cache_numpy export Image:1
-
     # By default, a tile size of 1024 is used. Specify values with
     $ omero zarr export Image:1 --tile_width 256 --tile_height 256
 
+
+NB: If the connection to OMERO is lost and the Image is partially exported,
+re-running the command will attempt to complete the export.
 
 To export images via bioformats2raw we use the ```--bf``` flag::
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,10 @@ To export Images or Plates via the OMERO API::
 
     # Cache each plane as a numpy file.npy. If connection is lost, and you need
     # to export again, we can use these instead of downloading again
-    # omero zarr --cache_numpy export Image:1
+    $ omero zarr --cache_numpy export Image:1
+
+    # By default, a tile size of 1024 is used. Specify values with
+    $ omero zarr export Image:1 --tile_width 256 --tile_height 256
 
 
 To export images via bioformats2raw we use the ```--bf``` flag::

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -126,12 +126,6 @@ class ZarrControl(BaseControl):
             "--output", type=str, default="", help="The output directory"
         )
 
-        parser.add_argument(
-            "--cache_numpy",
-            action="store_true",
-            help="Save planes as .npy files in case of connection loss",
-        )
-
         # Subcommands
         sub = parser.sub()
         polygons = parser.add(sub, self.polygons, POLYGONS_HELP)

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -68,7 +68,7 @@ bioformats2raw options
 
   --tile_width / --tile_height
 
-     Maximum tile width or height to read (only for use with bioformats2raw)
+     Maximum tile width or height to read
 
   --resolutions
 
@@ -249,12 +249,12 @@ class ZarrControl(BaseControl):
         export.add_argument(
             "--tile_width",
             default=None,
-            help="Maximum tile width to read (only for use with bioformats2raw)",
+            help="Maximum tile width",
         )
         export.add_argument(
             "--tile_height",
             default=None,
-            help="Maximum tile height to read (only for use with bioformats2raw)",
+            help="Maximum tile height",
         )
         export.add_argument(
             "--resolutions",

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -243,7 +243,11 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
     if acquisitions:
         plate_acq = [marshal_acquisition(x) for x in acquisitions]
 
-    for well in plate.listChildren():
+    wells = plate.listChildren()
+    # sort by row then column...
+    wells = sorted(wells, key=lambda x: (x.row * 100 + x.column))
+
+    for well in wells:
         row = plate.getRowLabels()[well.row]
         col = plate.getColumnLabels()[well.column]
         fields = []

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -57,7 +57,8 @@ def add_image(
     def get_cache_filename(*args: Any) -> str:
         assert cache_dir is not None
         dims = ["%03d" % dim for dim in args]
-        return os.path.join(cache_dir, str(image.id), f"{'-'.join(dims)}.npy")
+        pathname = os.path.join(cache_dir, str(image.id), *dims)
+        return pathname + ".npy"
 
     size_x = image.getSizeX()
     size_y = image.getSizeY()

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -118,9 +118,9 @@ def add_raw_image(
     for t in range(size_t):
         for c in range(size_c):
             for z in range(size_z):
-                for chk_x in range(chunk_count_x):
-                    for chk_y in range(chunk_count_y):
-                        print("t, c, z, chk_x, chk_y", t, c, z, chk_x, chk_y)
+                for chk_y in range(chunk_count_y):
+                    for chk_x in range(chunk_count_x):
+                        print("t, c, z, chk_x, chk_y", t, c, z, chk_y, chk_x)
                         x = tile_size * chk_x
                         y = tile_size * chk_y
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -245,7 +245,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
 
     wells = plate.listChildren()
     # sort by row then column...
-    wells = sorted(wells, key=lambda x: (x.row * 100 + x.column))
+    wells = sorted(wells, key=lambda x: (x.row, x.column))
 
     for well in wells:
         row = plate.getRowLabels()[well.row]

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -118,6 +118,9 @@ def add_raw_image(
         chunks=chunks,
         dtype=d_type,
     )
+    chunk_keys = list(zarray.chunk_store.keys())
+    separator = zarray.chunk_store.key_separator
+
     # Need to be sure that dims match (if array already existed)
     assert zarray.shape == shape
     msg = f"Chunks mismatch: existing {zarray.chunks} requested {chunks}"
@@ -148,10 +151,10 @@ def add_raw_image(
                         indices.append(np.s_[y:y_max:])
                         indices.append(np.s_[x:x_max:])
 
-                        existing_data = zarray[tuple(indices)]
-                        print("existing_data.max", existing_data.max())
-
-                        if existing_data.max() == 0:
+                        # Check if chunk exists. If not load from OMERO
+                        key_dims = [path, *indices[:-2], chk_y, chk_x]
+                        chunk_key = separator.join([str(k) for k in key_dims])
+                        if chunk_key not in chunk_keys:
                             print("loading Tile...")
                             tile = pixels.getTile(z, c, t, tile_dims)
                             zarray[tuple(indices)] = tile

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -66,9 +66,7 @@ def add_image(
     if cache_dir is not None:
         kwargs["cache_file_name_func"] = get_cache_filename
 
-    paths = add_raw_image(
-        image, parent, level_count, cache_file_name_func=get_cache_filename
-    )
+    paths = add_raw_image(image, parent, level_count, **kwargs)
 
     axes = marshal_axes(image)
     transformations = marshal_transformations(image, len(paths))

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -95,17 +95,15 @@ def add_raw_image(
     size_y = image.getSizeY()
     size_t = image.getSizeT()
 
-    rps = pixels._prepareRawPixelsStore()
-    tile_size_x, tile_size_y = rps.getTileSize()
+    tile_size = 512
 
     print(
         "sizes x: %s, y: %s, z: %s, c: %s, t: %s"
         % (size_x, size_y, size_z, size_c, size_t)
     )
-    print(f"tile_size_x: {tile_size_x}, tile_size_y: {tile_size_y}")
 
-    chunk_count_x = math.ceil(size_x / tile_size_x)
-    chunk_count_y = math.ceil(size_y / tile_size_y)
+    chunk_count_x = math.ceil(size_x / tile_size)
+    chunk_count_y = math.ceil(size_y / tile_size)
 
     # create 0 array
     path = "0"
@@ -113,7 +111,7 @@ def add_raw_image(
     zarray = parent.create(
         path,
         shape=tuple(dims + [size_y, size_x]),
-        chunks=tuple([1] * len(dims) + [tile_size_y, tile_size_x]),
+        chunks=tuple([1] * len(dims) + [tile_size, tile_size]),
         dtype=d_type,
     )
 
@@ -123,11 +121,11 @@ def add_raw_image(
                 for chk_x in range(chunk_count_x):
                     for chk_y in range(chunk_count_y):
                         print("t, c, z, chk_x, chk_y", t, c, z, chk_x, chk_y)
-                        x = tile_size_x * chk_x
-                        y = tile_size_y * chk_y
+                        x = tile_size * chk_x
+                        y = tile_size * chk_y
 
-                        y_max = min(size_y, y + tile_size_y)
-                        x_max = min(size_x, x + tile_size_x)
+                        y_max = min(size_y, y + tile_size)
+                        x_max = min(size_x, x + tile_size)
 
                         tile_dims = (x, y, x_max - x, y_max - y)
 

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -118,8 +118,6 @@ def add_raw_image(
         chunks=chunks,
         dtype=d_type,
     )
-    chunk_keys = list(zarray.chunk_store.keys())
-    separator = zarray.chunk_store.key_separator
 
     # Need to be sure that dims match (if array already existed)
     assert zarray.shape == shape
@@ -131,7 +129,10 @@ def add_raw_image(
             for z in range(size_z):
                 for chk_y in range(chunk_count_y):
                     for chk_x in range(chunk_count_x):
-                        print("t, c, z, chk_x, chk_y", t, c, z, chk_y, chk_x)
+                        print(
+                            "t, c, z, chk_x, chk_y %s %s %s %s %s"
+                            % (t, c, z, chk_y, chk_x)
+                        )
                         x = tile_width * chk_x
                         y = tile_height * chk_y
 
@@ -152,9 +153,8 @@ def add_raw_image(
                         indices.append(np.s_[x:x_max:])
 
                         # Check if chunk exists. If not load from OMERO
-                        key_dims = [path, *indices[:-2], chk_y, chk_x]
-                        chunk_key = separator.join([str(k) for k in key_dims])
-                        if chunk_key not in chunk_keys:
+                        existing_data = zarray[tuple(indices)]
+                        if existing_data.max() == 0:
                             print("loading Tile...")
                             tile = pixels.getTile(z, c, t, tile_dims)
                             zarray[tuple(indices)] = tile


### PR DESCRIPTION
Fixes #111

This adds support for exporting big images in a tile-based approach instead of a plane-based approach.
As suggested by @joshmoore - this tile-based approach is used for ALL images (instead of using the whole plane for as a single chunk as before).

First we write a full-size array at `0`, a tile at a time.
Then resize via `ome_zarr.dask_utils.resize` (see bug-fix at https://github.com/ome/ome-zarr-py/pull/244)
to create a pyramid.

Other changes:

The `--numpy_cache` functionality has been replaced.
Previously, if you anticipated connection issues with OMERO, you could use the `--numpy_cache` option to cache chunks to disk at the same time as writing them to zarr. The problem with this was that if you lost connection and weren't expecting it, then you had nothing cached. Also, caching doubled the disk usage.

Now, if connection fails, you can simply rerun the `omero zarr export Image:ID` command and we pick-up writing to the existing partially-generated array.

This is nicer as you don't have to delete the partially-exported image as before and it's much faster as you do don't have to copy the cached chunks and re-write to zarr.
Exporting the big image below required many re-runs of the export command - maybe 20 - 30 times before completion!

The `tile_width` and `tile_height` options that previously only applied to `bioformats2raw` usage, now also apply to API-based export.

Image exported with this PR is at:
https://ome.github.io/ome-ngff-validator/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846152.zarr/

I also fixed the Plate export to work with the new export logic and to support the interruption (partial export) of a Plate and the continued export from where you left off.

