### PR TITLE
Remove np.bool alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+# 0.5.2 (May 2023)
+
+- Remove numpy.bool alias ([#143](https://github.com/ome/omero-cli-zarr/pull/143))
+
 # 0.5.1 (November 2022)
 
 - Fix axes "units" to "unit" ([#131](https://github.com/ome/omero-cli-zarr/pull/131))

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -51,7 +51,7 @@ DIMENSION_ORDER: Dict[str, int] = {
 }
 
 MASK_DTYPE_SIZE: Dict[int, np.dtype] = {
-    1: np.bool,
+    1: bool,
     8: np.int8,
     16: np.int16,
     32: np.int32,
@@ -550,7 +550,7 @@ class MaskSaver:
                         ):
                             overlap = np.logical_and(
                                 labels[i_t, i_c, i_z, y : (y + h), x : (x + w)].astype(
-                                    np.bool
+                                    bool
                                 ),
                                 binim_yx,
                             )


### PR DESCRIPTION
As reported by @jburel, trying to export labels with recent numpy (e.g. `numpy==1.24.3`) fails (Error below).

See https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

<details><summary>Error</summary>

```
$ omero zarr masks Image:6001240
/Users/wmoore/Desktop/ZARR/omero-cli-zarr/src/omero_zarr/masks.py:54: FutureWarning: In the future `np.bool` will be defined as the corresponding NumPy scalar.
  1: np.bool,
Error loading: /Users/wmoore/Desktop/ZARR/omero-cli-zarr/src/omero/plugins/zarr.py
Traceback (most recent call last):
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/site-packages/omero/cli.py", line 1690, in loadpath
    execfile(str(pathobj), loc)
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/site-packages/past/builtins/misc.py", line 154, in execfile
    exec_(code, myglobals, mylocals)
  File "/Users/wmoore/Desktop/ZARR/omero-cli-zarr/src/omero/plugins/zarr.py", line 1, in <module>
    from omero_zarr.cli import HELP, ZarrControl
  File "/Users/wmoore/Desktop/ZARR/omero-cli-zarr/src/omero_zarr/cli.py", line 32, in <module>
    from .masks import (
  File "/Users/wmoore/Desktop/ZARR/omero-cli-zarr/src/omero_zarr/masks.py", line 54, in <module>
    1: np.bool,
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
</details>

This fixes as described.

To test:

```
$ omero login   # to IDR
$ omero zarr export Image:6001240
$ omero zarr masks Image:6001240
```
