### PR TITLE
Use correct dimension_separator when downsampling

### DIFF
--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -207,7 +207,12 @@ def downsample_pyramid_on_disk(parent: Group, paths: List[str]) -> List[str]:
         )
 
         # write to disk
-        da.to_zarr(arr=output, url=image_path, component=path)
+        da.to_zarr(
+            arr=output,
+            url=parent.store,
+            component=str(path),
+            dimension_separator=parent._store._dimension_separator,
+        )
 
     return paths
 


### PR DESCRIPTION
I noticed that a bug introduced in https://github.com/ome/omero-cli-zarr/pull/134
When creating pyramids with `downsample_pyramid_on_disk()` the `da.to_zarr()` doesn't respect dimension separator.

For example of data exported with this issue: see https://ome.github.io/ome-ngff-validator/?source=https://uk1s3.embassy.ebi.ac.uk/idr0036/zarr/4403.zarr/A/1/0/

Fix is similar to https://github.com/ome/ome-zarr-py/pull/243

To test:

```
$ omero zarr export Image:123
```
check that array at `123.zarr/1/` has dimension separator `/` 