### PR TITLE
Fix path/to/image when exporting Plate images

### DIFF
--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -209,8 +209,8 @@ def downsample_pyramid_on_disk(parent: Group, paths: List[str]) -> List[str]:
         # write to disk
         da.to_zarr(
             arr=output,
-            url=parent.store,
-            component=str(path),
+            url=image_path,
+            component=path,
             dimension_separator=parent._store._dimension_separator,
         )
 


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/ome/omero-cli-zarr/pull/144 where the `well/field/image` path wasn't being passed to `da.to_zarr()` when downsampling images during Plate export.

To test:

```
omero zarr export Plate:123
```

This bug didn't affect the export of single Images (which was tested on that PR).
Without this fix, the first downsampled image `1` gets written to `plate.zarr/1/.zarray` and then this is not found when we try to read it to downsample again (since we're still looking in the "right" place at `plate.zarr/A/1/0/1/.zarray`):

```
Traceback (most recent call last):
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/site-packages/zarr/core.py", line 243, in _load_metadata_nosync
    meta_bytes = self._store[mkey]
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/site-packages/zarr/storage.py", line 1087, in __getitem__
    raise KeyError(key)
KeyError: '.zarray'
```