### PR TITLE
Pixel type fix

### DIFF
--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -33,6 +33,16 @@ from ome_zarr.writer import (
     write_well_metadata,
 )
 from omero.model import Channel
+from omero.model.enums import (
+    PixelsTypedouble,
+    PixelsTypefloat,
+    PixelsTypeint8,
+    PixelsTypeint16,
+    PixelsTypeint32,
+    PixelsTypeuint8,
+    PixelsTypeuint16,
+    PixelsTypeuint32,
+)
 from omero.rtypes import unwrap
 from zarr.hierarchy import Group, open_group
 
@@ -99,7 +109,18 @@ def add_raw_image(
     tile_height: Optional[int] = None,
 ) -> List[str]:
     pixels = image.getPrimaryPixels()
-    d_type = image.getPixelsType()
+    pixelTypes = {
+        PixelsTypeint8: ["b", np.int8],
+        PixelsTypeuint8: ["B", np.uint8],
+        PixelsTypeint16: ["h", np.int16],
+        PixelsTypeuint16: ["H", np.uint16],
+        PixelsTypeint32: ["i", np.int32],
+        PixelsTypeuint32: ["I", np.uint32],
+        PixelsTypefloat: ["f", np.float32],
+        PixelsTypedouble: ["d", np.float64],
+    }
+    pixelType = pixels.getPixelsType().value
+    d_type = pixelTypes[pixelType][1]
     size_c = image.getSizeC()
     size_z = image.getSizeZ()
     size_x = image.getSizeX()

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -109,6 +109,7 @@ def add_raw_image(
     tile_height: Optional[int] = None,
 ) -> List[str]:
     pixels = image.getPrimaryPixels()
+    omero_dtype = image.getPixelsType()
     pixelTypes = {
         PixelsTypeint8: ["b", np.int8],
         PixelsTypeuint8: ["B", np.uint8],
@@ -119,8 +120,7 @@ def add_raw_image(
         PixelsTypefloat: ["f", np.float32],
         PixelsTypedouble: ["d", np.float64],
     }
-    pixelType = pixels.getPixelsType().value
-    d_type = pixelTypes[pixelType][1]
+    d_type = pixelTypes[omero_dtype][1]
     size_c = image.getSizeC()
     size_z = image.getSizeZ()
     size_x = image.getSizeX()


### PR DESCRIPTION
Images in OMERO with `float` pixelType are `float-32` (`f4`: 4 bytes per pixel) but are currently exported as `f8`.
E.g. https://idr.openmicroscopy.org/webclient/?show=image-10648046 was exported as
https://ome.github.io/ome-ngff-validator/?source=https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD852/971f2809-c748-4259-8044-81ba6c774fdd/971f2809-c748-4259-8044-81ba6c774fdd.zarr

This is because we have previously used `np.dtype(omeroDtype)` which gives the `float64` dtype by default:

```
>>> from omero.model.enums import PixelsTypefloat
>>> PixelsTypefloat
'float'
>>> np.dtype(PixelsTypefloat)
dtype('float64')
```

To test:

```
omero zarr export Image:10648046
ome_zarr view 10648046.zarr
```

Should see `Type: <f4`