### PR TITLE
scm version fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,5 @@ setup(
     keywords=["OMERO.CLI", "plugin"],
     url="https://github.com/ome/omero-cli-zarr/",
     setup_requires=["setuptools_scm"],
-    use_scm_version={"write_to": "src/omero_zarr/_version.py"},
+    use_scm_version={"version_file": "src/omero_zarr/_version.py"},
 )


### PR DESCRIPTION
Use version_file instead of write_to for scm_version

As a breaking change in https://github.com/pypa/setuptools_scm/blob/main/CHANGELOG.md#v800
is "introduce `version_file` as replacement for `write_to`".

This PR makes the corresponding change.