### PR TITLE
Downsample scale option

### DIFF
--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -283,6 +283,12 @@ class ZarrControl(BaseControl):
             type=ProxyStringType("Image"),
             help="The Image to export.",
         )
+        export.add_argument(
+            "--ds_scale",
+            type=str,
+            default=None,
+            help="Downsample scale factors, e.g. 1,1,2,2,2",
+        )
 
         for subcommand in (polygons, masks, export):
             subcommand.add_argument(

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -294,8 +294,8 @@ class ZarrControl(BaseControl):
             "--ds_scale",
             type=str,
             default=None,
-            help="Downsample scale factors, e.g. 1,1,2,2,2, omitting dimensions"
-            " of size 1 which will be squeezed out of the exported Image",
+            help="Downsample scale factors, e.g. 1,1,2,2,2, omitting dimensions where "
+            "the image is size 1, since they will be squeezed from the exported Image",
         )
 
         for subcommand in (polygons, masks, export):

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -244,6 +244,13 @@ class ZarrControl(BaseControl):
                 "overlapping labels"
             ),
         )
+        masks.add_argument(
+            "--ds_scale",
+            type=str,
+            default=None,
+            help="Downsample scale factors, e.g. 1,1,2,2,2, omitting Image"
+            " dimensions of size 1 which will be squeezed out of the exported labels",
+        )
 
         export = parser.add(sub, self.export, EXPORT_HELP)
         export.add_argument(
@@ -287,7 +294,8 @@ class ZarrControl(BaseControl):
             "--ds_scale",
             type=str,
             default=None,
-            help="Downsample scale factors, e.g. 1,1,2,2,2",
+            help="Downsample scale factors, e.g. 1,1,2,2,2, omitting dimensions"
+            " of size 1 which will be squeezed out of the exported Image",
         )
 
         for subcommand in (polygons, masks, export):


### PR DESCRIPTION
For an Image of `C:3, Z:10, Y:1024, X: 1024` you may wish to NOT downsample in Z when exporting. Only downsample in X and Y, e.g.

```
omero zarr export Image:123 --ds_scale 1,1,2,2
```

Whereas if you have an image with `C:3, Z:1024, Y:1024, X: 1024` you may wish to downsample in Z, e.g.

```
omero zarr export Image:123 --ds_scale 1,2,2,2
```

This option gives complete flexibility over downsampling of all dimensions. Too complex?

Compare with ngff-zarr which has 

```
scale_factors : int of minimum length, int per scale or dict of spatial dimension int's per scale
        If a single integer, scale factors in spatial dimensions will be increased by a factor of two until this minimum length is reached.
        If a list, integer scale factors to apply uniformly across all spatial dimensions or
        along individual spatial dimensions.
        Examples: 64 or [2, 4] or [{'x': 2, 'y': 4 }, {'x': 5, 'y': 10}]
```

at https://github.com/thewtex/ngff-zarr/blob/4a154994a85e2d222999bb3e5d67ab96f5060244/ngff_zarr/to_multiscales.py#L219
