### PR TITLE
Add extinfo command

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = dask,numpy,ome_zarr,omero,omero_rois,omero_zarr,pytest,setuptools,skimage,zarr
+known_third_party = dask,numpy,ome_zarr,omero,omero_rois,omero_sys_ParametersI,omero_zarr,pytest,setuptools,skimage,zarr

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -305,9 +305,9 @@ class ZarrControl(BaseControl):
             help="Set the ExternalInfo path"
         )
         extinfo.add_argument(
-            "--path",
+            "--lsid",
             default=None,
-            help="Use a specific path (default: Determine from clientPath) (only used in combination with --set)"
+            help="Use a specific lsid (path) (default: Determine from clientPath) (only used in combination with --set)"
         )
         extinfo.add_argument(
             "--entityType",
@@ -384,7 +384,7 @@ class ZarrControl(BaseControl):
             extinfo = get_extinfo(self.gateway, img)
             if args.set:
                 try:
-                    img = set_external_info(self.gateway, img, well, idx, args.path, args.entityType, int(args.entityId))
+                    img = set_external_info(self.gateway, img, well, idx, args.lsid, args.entityType, int(args.entityId))
                     img = self.gateway.getUpdateService().saveAndReturnObject(img)
                     self.ctx.out(f"Set ExternalInfo for image ({img.id._val}) {img.name._val}:\n{external_info_str(img.details.externalInfo)}")
                 except Exception as e:

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -325,10 +325,10 @@ class ZarrControl(BaseControl):
             help="Set the ExternalInfo path",
         )
         extinfo.add_argument(
-            "--lsid",
+            "--zarrPath",
             default=None,
             help=(
-                "Use a specific lsid (path) (default: Determine from "
+                "Use a specific path (default: Determine from "
                 "clientPath) (only used in combination with --set)"
             ),
         )
@@ -424,7 +424,7 @@ class ZarrControl(BaseControl):
                         img,
                         well,
                         idx,
-                        args.lsid,
+                        args.zarrPath,
                         args.entityType,
                         int(args.entityId),
                     )

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -29,6 +29,7 @@ from omero.model import ImageI, PlateI
 from zarr.hierarchy import open_group
 from zarr.storage import FSStore
 
+from .extinfo import external_info_str, get_extinfo, get_images, set_external_info
 from .masks import (
     MASK_DTYPE_SIZE,
     MaskSaver,
@@ -40,12 +41,6 @@ from .raw_pixels import (
     add_toplevel_metadata,
     image_to_zarr,
     plate_to_zarr,
-)
-from .extinfo import (
-    get_images,
-    set_external_info,
-    get_extinfo,
-    external_info_str
 )
 
 HELP = """Export data in zarr format.
@@ -205,8 +200,7 @@ class ZarrControl(BaseControl):
         polygons.add_argument(
             "--label-name",
             help=(
-                "Name of the array that will be stored. Ignored for "
-                "--style=split"
+                "Name of the array that will be stored. Ignored for " "--style=split"
             ),
             default="0",
         )
@@ -236,8 +230,7 @@ class ZarrControl(BaseControl):
         masks.add_argument(
             "--label-name",
             help=(
-                "Name of the array that will be stored. Ignored for "
-                "--style=split"
+                "Name of the array that will be stored. Ignored for " "--style=split"
             ),
             default="0",
         )
@@ -302,10 +295,7 @@ class ZarrControl(BaseControl):
         export.add_argument(
             "--max_workers",
             default=None,
-            help=(
-                "Maximum number of workers (only for "
-                "use with bioformats2raw)"
-            ),
+            help=("Maximum number of workers (only for " "use with bioformats2raw)"),
         )
         export.add_argument(
             "object",
@@ -428,8 +418,7 @@ class ZarrControl(BaseControl):
                         args.entityType,
                         int(args.entityId),
                     )
-                    img = self.gateway.getUpdateService()\
-                        .saveAndReturnObject(img)
+                    img = self.gateway.getUpdateService().saveAndReturnObject(img)
                     self.ctx.out(
                         f"Set ExternalInfo for image ({img.id._val}) "
                         f"{img.name._val}:\n"
@@ -443,16 +432,14 @@ class ZarrControl(BaseControl):
             elif args.reset:
                 if extinfo:
                     img.details.externalInfo = None
-                    img = self.gateway.getUpdateService()\
-                        .saveAndReturnObject(img)
+                    img = self.gateway.getUpdateService().saveAndReturnObject(img)
                     self.ctx.out(
                         f"Removed ExternalInfo from image "
                         f"({img.id._val}) {img.name._val}"
                     )
                 else:
                     self.ctx.out(
-                        f"Image ({img.id._val}) {img.name._val} "
-                        "has no ExternalInfo"
+                        f"Image ({img.id._val}) {img.name._val} " "has no ExternalInfo"
                     )
             else:
                 if extinfo:
@@ -463,8 +450,7 @@ class ZarrControl(BaseControl):
                     )
                 else:
                     self.ctx.out(
-                        f"Image ({img.id._val}) {img.name._val} has no "
-                        "ExternalInfo"
+                        f"Image ({img.id._val}) {img.name._val} has no " "ExternalInfo"
                     )
 
     def _lookup(
@@ -477,9 +463,7 @@ class ZarrControl(BaseControl):
             self.ctx.die(110, f"No such {otype}: {oid}")
         return obj
 
-    def _bf_export(
-        self, image: BlitzObjectWrapper, args: argparse.Namespace
-    ) -> None:
+    def _bf_export(self, image: BlitzObjectWrapper, args: argparse.Namespace) -> None:
         if args.bfpath:
             abs_path = Path(args.bfpath)
         elif image.getInplaceImport():

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -57,6 +57,7 @@ Subcommands
  - masks
 
 """
+
 EXPORT_HELP = """Export an image in zarr format.
 
 Using bioformats2raw
@@ -120,6 +121,7 @@ Use --set to set the external info path
 or --reset in order to remove the ExternalInfo from the image.
 """
 
+
 def gateway_required(func: Callable) -> Callable:
     """
     Decorator which initializes a client (self.client),
@@ -175,7 +177,7 @@ class ZarrControl(BaseControl):
             "--style",
             choices=("split", "labeled"),
             default="labeled",
-            help=("Choice of storage for ROIs [breaks ome-zarr]"),
+            help="Choice of storage for ROIs [breaks ome-zarr]",
         )
         polygons.add_argument(
             "--label-path",
@@ -188,8 +190,8 @@ class ZarrControl(BaseControl):
         polygons.add_argument(
             "--source-image",
             help=(
-                "Path to the multiscales group containing the source image/plate. "
-                "By default, use the output directory"
+                "Path to the multiscales group containing the source "
+                "image/plate. By default, use the output directory"
             ),
             default=None,
         )
@@ -202,7 +204,10 @@ class ZarrControl(BaseControl):
         )
         polygons.add_argument(
             "--label-name",
-            help=("Name of the array that will be stored. Ignored for --style=split"),
+            help=(
+                "Name of the array that will be stored. Ignored for "
+                "--style=split"
+            ),
             default="0",
         )
 
@@ -215,8 +220,8 @@ class ZarrControl(BaseControl):
         masks.add_argument(
             "--source-image",
             help=(
-                "Path to the multiscales group containing the source image/plate. "
-                "By default, use the output directory"
+                "Path to the multiscales group containing the source "
+                "image/plate. By default, use the output directory"
             ),
             default=None,
         )
@@ -230,14 +235,17 @@ class ZarrControl(BaseControl):
         )
         masks.add_argument(
             "--label-name",
-            help=("Name of the array that will be stored. Ignored for --style=split"),
+            help=(
+                "Name of the array that will be stored. Ignored for "
+                "--style=split"
+            ),
             default="0",
         )
         masks.add_argument(
             "--style",
             choices=("split", "labeled"),
             default="labeled",
-            help=("Choice of storage for ROIs [breaks ome-zarr]"),
+            help="Choice of storage for ROIs [breaks ome-zarr]",
         )
         masks.add_argument(
             "--label-bits",
@@ -260,13 +268,18 @@ class ZarrControl(BaseControl):
         export.add_argument(
             "--bf",
             action="store_true",
-            help="Use bioformats2raw on the server to export images. Requires"
-            " bioformats2raw 0.3.0 or higher and access to the managed repo.",
+            help=(
+                "Use bioformats2raw on the server to export images. Requires "
+                "bioformats2raw 0.3.0 or higher and access to the managed "
+                "repo."
+            ),
         )
         export.add_argument(
             "--bfpath",
-            help="Use bioformats2raw on a local copy of a file. Requires"
-            " bioformats2raw 0.4.0 or higher.",
+            help=(
+                "Use bioformats2raw on a local copy of a file. Requires "
+                "bioformats2raw 0.4.0 or higher."
+            ),
         )
         export.add_argument(
             "--tile_width",
@@ -281,13 +294,18 @@ class ZarrControl(BaseControl):
         export.add_argument(
             "--resolutions",
             default=None,
-            help="Number of pyramid resolutions to generate"
-            " (only for use with bioformats2raw)",
+            help=(
+                "Number of pyramid resolutions to generate "
+                "(only for use with bioformats2raw)"
+            ),
         )
         export.add_argument(
             "--max_workers",
             default=None,
-            help="Maximum number of workers (only for use with bioformats2raw)",
+            help=(
+                "Maximum number of workers (only for "
+                "use with bioformats2raw)"
+            ),
         )
         export.add_argument(
             "object",
@@ -296,38 +314,53 @@ class ZarrControl(BaseControl):
         )
 
         extinfo = parser.add(sub, self.extinfo, EXTINFO_HELP)
-        extinfo.add_argument("object",  
-                type=ProxyStringType(),
-                help="Object in Class:ID format")
+        extinfo.add_argument(
+            "object",
+            type=ProxyStringType(),
+            help="Object in Class:ID format",
+        )
         extinfo.add_argument(
             "--set",
             action="store_true",
-            help="Set the ExternalInfo path"
+            help="Set the ExternalInfo path",
         )
         extinfo.add_argument(
             "--lsid",
             default=None,
-            help="Use a specific lsid (path) (default: Determine from clientPath) (only used in combination with --set)"
+            help=(
+                "Use a specific lsid (path) (default: Determine from "
+                "clientPath) (only used in combination with --set)"
+            ),
         )
         extinfo.add_argument(
             "--entityType",
             default="com.glencoesoftware.ngff:multiscales",
-            help="Use a specific entityType (default: com.glencoesoftware.ngff:multiscales) (only used in combination with --set)"
+            help=(
+                "Use a specific entityType (default: "
+                "com.glencoesoftware.ngff:multiscales) "
+                "(only used in combination with --set)"
+            ),
         )
         extinfo.add_argument(
             "--entityId",
             default="3",
-            help="Use a specific entityId (default: 3) (only used in combination with --set)"
+            help=(
+                "Use a specific entityId (default: 3) "
+                "(only used in combination with --set)"
+            ),
         )
         extinfo.add_argument(
             "--reset",
             action="store_true",
-            help="Removes the ExternalInfo"
+            help="Removes the ExternalInfo",
         )
 
         for subcommand in (polygons, masks, export):
             subcommand.add_argument(
-                "--output", type=str, default="", help="The output directory"
+                "--output",
+                type=str,
+                default="",
+                help="The output directory",
             )
         for subcommand in (polygons, masks):
             subcommand.add_argument(
@@ -335,9 +368,11 @@ class ZarrControl(BaseControl):
                 type=str,
                 default=MaskSaver.OVERLAPS[0],
                 choices=MaskSaver.OVERLAPS,
-                help="To allow overlapping shapes, use 'dtype_max':"
-                " All overlapping regions will be set to the"
-                " max value for the dtype",
+                help=(
+                    "To allow overlapping shapes, use 'dtype_max': "
+                    "All overlapping regions will be set to the "
+                    "max value for the dtype"
+                ),
             )
 
     @gateway_required
@@ -376,7 +411,6 @@ class ZarrControl(BaseControl):
             plate = self._lookup(self.gateway, "Plate", args.object.id)
             plate_to_zarr(plate, args)
 
-
     @gateway_required
     def extinfo(self, args: argparse.Namespace) -> None:
         for img, well, idx in get_images(self.gateway, args.object):
@@ -384,24 +418,53 @@ class ZarrControl(BaseControl):
             extinfo = get_extinfo(self.gateway, img)
             if args.set:
                 try:
-                    img = set_external_info(self.gateway, img, well, idx, args.lsid, args.entityType, int(args.entityId))
-                    img = self.gateway.getUpdateService().saveAndReturnObject(img)
-                    self.ctx.out(f"Set ExternalInfo for image ({img.id._val}) {img.name._val}:\n{external_info_str(img.details.externalInfo)}")
+                    img = set_external_info(
+                        self.gateway,
+                        img,
+                        well,
+                        idx,
+                        args.lsid,
+                        args.entityType,
+                        int(args.entityId),
+                    )
+                    img = self.gateway.getUpdateService()\
+                        .saveAndReturnObject(img)
+                    self.ctx.out(
+                        f"Set ExternalInfo for image ({img.id._val}) "
+                        f"{img.name._val}:\n"
+                        f"{external_info_str(img.details.externalInfo)}"
+                    )
                 except Exception as e:
-                    self.ctx.err(f"Failed to set external info for image ({img.id._val}) {img.name._val}: {e}")
+                    self.ctx.err(
+                        f"Failed to set external info for image "
+                        f"({img.id._val}) {img.name._val}: {e}"
+                    )
             elif args.reset:
                 if extinfo:
                     img.details.externalInfo = None
-                    img = self.gateway.getUpdateService().saveAndReturnObject(img)
-                    self.ctx.out(f"Removed ExternalInfo from image ({img.id._val}) {img.name._val}")
+                    img = self.gateway.getUpdateService()\
+                        .saveAndReturnObject(img)
+                    self.ctx.out(
+                        f"Removed ExternalInfo from image "
+                        f"({img.id._val}) {img.name._val}"
+                    )
                 else:
-                    self.ctx.out(f"Image ({img.id._val}) {img.name._val} has no ExternalInfo")
+                    self.ctx.out(
+                        f"Image ({img.id._val}) {img.name._val} "
+                        "has no ExternalInfo"
+                    )
             else:
                 if extinfo:
-                    self.ctx.out(f"ExternalInfo for image ({img.id._val}) {img.name._val}:\n{external_info_str(extinfo)}")
+                    self.ctx.out(
+                        f"ExternalInfo for image ({img.id._val}) "
+                        f"{img.name._val}:\n"
+                        f"{external_info_str(extinfo)}"
+                    )
                 else:
-                    self.ctx.out(f"Image ({img.id._val}) {img.name._val} has no ExternalInfo")
-
+                    self.ctx.out(
+                        f"Image ({img.id._val}) {img.name._val} has no "
+                        "ExternalInfo"
+                    )
 
     def _lookup(
         self, gateway: BlitzGateway, otype: str, oid: int
@@ -413,7 +476,9 @@ class ZarrControl(BaseControl):
             self.ctx.die(110, f"No such {otype}: {oid}")
         return obj
 
-    def _bf_export(self, image: BlitzObjectWrapper, args: argparse.Namespace) -> None:
+    def _bf_export(
+        self, image: BlitzObjectWrapper, args: argparse.Namespace
+    ) -> None:
         if args.bfpath:
             abs_path = Path(args.bfpath)
         elif image.getInplaceImport():

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -415,6 +415,7 @@ class ZarrControl(BaseControl):
     def extinfo(self, args: argparse.Namespace) -> None:
         for img, well, idx in get_images(self.gateway, args.object):
             img = img._obj
+            group_id = img.getDetails().getGroup().id.val
             extinfo = get_extinfo(self.gateway, img)
             if args.set:
                 try:

--- a/src/omero_zarr/extinfo.py
+++ b/src/omero_zarr/extinfo.py
@@ -1,0 +1,71 @@
+from omero.gateway import BlitzGateway
+from omero.gateway import BlitzObjectWrapper
+from omero.model import ExternalInfoI, ImageI
+from omero.rtypes import rstring, rlong
+from omero_sys_ParametersI import ParametersI
+from omero.model import Image
+from omero.model import Plate
+from omero.model import Screen
+from omero.model import Dataset
+from omero.model import Project
+
+
+def get_path(conn: BlitzGateway, image_id: int) -> str:
+    params = ParametersI()
+    params.addId(image_id)
+    query = """
+        select fs from Fileset as fs
+        join fetch fs.images as image
+        left outer join fetch fs.usedFiles as usedFile
+        join fetch usedFile.originalFile as f
+        join fetch f.hasher where image.id = :id
+    """
+    fs = conn.getQueryService().findByQuery(query, params)
+    res = fs._getUsedFiles()[0]._clientPath._val
+    return res
+
+
+def set_external_info(img: ImageI, path: str) -> ImageI:
+    info = ExternalInfoI()
+    info.entityType = rstring("com.glencoesoftware.ngff:multiscales")
+    info.entityId = rlong(3)
+    info.lsid = rstring(path)
+    img.details.externalInfo = info
+    return img
+
+
+def _lookup(conn: BlitzGateway, type: str, oid: int) -> BlitzObjectWrapper:
+    conn.SERVICE_OPTS.setOmeroGroup("-1")
+    obj = conn.getObject(type, oid)
+    if not obj:
+        raise ValueError(f"No such {type}: {oid}")
+    return obj
+
+
+def get_images(conn: BlitzGateway, object):
+    if isinstance(object, list):
+        for x in object:
+            yield from get_images(conn, x)
+    elif isinstance(object, Screen):
+        scr = _lookup(conn, "Screen", object.id)
+        for plate in scr.listChildren():
+            yield from get_images(conn, plate._obj)
+    elif isinstance(object, Plate):
+        plt = _lookup(conn, "Plate", object.id)
+        for well in plt.listChildren():
+            for idx in range(0, well.countWellSample()):
+                img = well.getImage(idx)
+                yield img
+    elif isinstance(object, Project):
+        prj = _lookup(conn, "Project", object.id)
+        for ds in prj.listChildren():
+            yield from get_images(conn, ds._obj)
+    elif isinstance(object, Dataset):
+        ds = _lookup(conn, "Dataset", object.id)
+        for img in ds.listChildren():
+            yield img
+    elif isinstance(object, Image):
+        img = _lookup(conn, "Image", object.id)
+        yield img
+    else:
+        raise ValueError(f"Unsupported type: {object.__class__.__name__}")

--- a/src/omero_zarr/extinfo.py
+++ b/src/omero_zarr/extinfo.py
@@ -1,14 +1,17 @@
-from omero.gateway import BlitzGateway, ImageWrapper
-from omero.gateway import BlitzObjectWrapper
-from omero.model import ExternalInfoI, ImageI
-from omero.rtypes import rstring, rlong
-from omero_sys_ParametersI import ParametersI
-from omero.model import Image
-from omero.model import Plate
-from omero.model import Screen
-from omero.model import Dataset
-from omero.model import Project
 import re
+
+from omero.gateway import BlitzGateway, BlitzObjectWrapper, ImageWrapper
+from omero.model import (
+    Dataset,
+    ExternalInfoI,
+    Image,
+    ImageI,
+    Plate,
+    Project,
+    Screen,
+)
+from omero.rtypes import rlong, rstring
+from omero_sys_ParametersI import ParametersI
 
 
 # Regex to match well positions (eg. A1)

--- a/src/omero_zarr/extinfo.py
+++ b/src/omero_zarr/extinfo.py
@@ -8,9 +8,27 @@ from omero.model import Plate
 from omero.model import Screen
 from omero.model import Dataset
 from omero.model import Project
+import re
 
 
-def get_path(conn: BlitzGateway, image_id: int) -> str:
+# Regex to match well positions (eg. A1)
+WELL_POS_RE = re.compile(r"(?P<row>\D+)(?P<col>\d+)")
+
+
+def _get_path(conn: BlitzGateway, image_id: int) -> str:
+    """
+    Retrieve the (first) original file path for a given OMERO image.
+
+    Args:
+        conn (BlitzGateway): Active OMERO gateway connection
+        image_id (int): ID of the OMERO image
+
+    Returns:
+        str: path of the image file
+
+    Raises:
+        Exception: If the query fails or the path cannot be retrieved
+    """
     params = ParametersI()
     params.addId(image_id)
     query = """
@@ -25,16 +43,21 @@ def get_path(conn: BlitzGateway, image_id: int) -> str:
     return res
 
 
-def set_external_info(img: ImageI, path: str) -> ImageI:
-    info = ExternalInfoI()
-    info.entityType = rstring("com.glencoesoftware.ngff:multiscales")
-    info.entityId = rlong(3)
-    info.lsid = rstring(path)
-    img.details.externalInfo = info
-    return img
-
-
 def _lookup(conn: BlitzGateway, type: str, oid: int) -> BlitzObjectWrapper:
+    """
+    Look up an OMERO object by its type and ID.
+
+    Args:
+        conn (BlitzGateway): Active OMERO gateway connection
+        type (str): Type of OMERO object (e.g., "Screen", "Plate", "Image")
+        oid (int): Object ID to look up
+
+    Returns:
+        BlitzObjectWrapper: Wrapped OMERO object
+
+    Raises:
+        ValueError: If the object doesn't exist
+    """
     conn.SERVICE_OPTS.setOmeroGroup("-1")
     obj = conn.getObject(type, oid)
     if not obj:
@@ -42,7 +65,27 @@ def _lookup(conn: BlitzGateway, type: str, oid: int) -> BlitzObjectWrapper:
     return obj
 
 
-def get_images(conn: BlitzGateway, object):
+def get_images(conn: BlitzGateway, object) -> tuple[BlitzObjectWrapper, str | None, int | None]:
+    """
+    Generator that yields images from any OMERO container object.
+
+    Recursively traverses OMERO container hierarchies (Screen/Plate/Project/Dataset)
+    to find all contained images.
+
+    Args:
+        conn (BlitzGateway): Active OMERO gateway connection
+        object: OMERO container object (Screen, Plate, Project, Dataset, Image)
+              or a list of such objects
+
+    Yields:
+        tuple: Contains:
+            - BlitzObjectWrapper: Image object
+            - str | None: Well position (eg. A1) if from plate, None otherwise
+            - int | None: Well sample index if from plate, None otherwise
+
+    Raises:
+        ValueError: If given an unsupported object type
+    """
     if isinstance(object, list):
         for x in object:
             yield from get_images(conn, x)
@@ -55,7 +98,7 @@ def get_images(conn: BlitzGateway, object):
         for well in plt.listChildren():
             for idx in range(0, well.countWellSample()):
                 img = well.getImage(idx)
-                yield img
+                yield img, well.getWellPos(), idx
     elif isinstance(object, Project):
         prj = _lookup(conn, "Project", object.id)
         for ds in prj.listChildren():
@@ -63,9 +106,65 @@ def get_images(conn: BlitzGateway, object):
     elif isinstance(object, Dataset):
         ds = _lookup(conn, "Dataset", object.id)
         for img in ds.listChildren():
-            yield img
+            yield img, None, None
     elif isinstance(object, Image):
         img = _lookup(conn, "Image", object.id)
-        yield img
+        yield img, None, None
     else:
         raise ValueError(f"Unsupported type: {object.__class__.__name__}")
+
+
+def set_external_info(conn: BlitzGateway, img: ImageI, well: str, idx: int) -> ImageI:
+    """
+    Set external info for an image to enable omero zarr pixel buffer handling.
+    
+    This function configures an image for use with the omero-zarr-pixel-buffer by:
+    1. Retrieving the original file path
+    2. Converting it to point to the 5d multiscale image directory
+    3. Setting up the external info with the path and metadata
+    
+    For plate-based images (with wells), the path structure follows:
+    /<base_path>/<row>/<column>/<field index>
+    
+    For regular images:
+    /<base_path>/0
+    
+    Args:
+        conn (BlitzGateway): Active OMERO gateway connection
+        img (ImageI): OMERO image object to modify
+        well (str): Well position (e.g., 'A1', 'B2') for plate-based images, or None
+        idx (int): Well sample / field index for plate-based images, or None
+        
+    Returns:
+        ImageI: Modified image object with updated external info
+        
+    Raises:
+        ValueError: If the image path is not an OME-Zarr format or if well position is invalid
+        
+    Note:
+        The external info is configured with entity type 'com.glencoesoftware.ngff:multiscales'
+        and entity ID 3, which are required by the omero-zarr-pixel-buffer.
+    """
+    path = _get_path(conn, img.id)
+    if path.endswith("OME/METADATA.ome.xml"):
+        if well:
+            match = WELL_POS_RE.match(well)
+            if match:
+                col = match.group("col")
+                row = match.group("row")
+                path = path.replace("OME/METADATA.ome.xml", f"{row}")
+                path = f"/{path}/{col}/{idx}"
+            else:
+                raise ValueError(f"Couldn't parse well position: {well}")
+        else:
+            path = path.replace("OME/METADATA.ome.xml", "0")
+            path = f"/{path}"
+    else:
+        raise ValueError(f"Doesn't seem to be an ome.zarr: {path}")
+
+    info = ExternalInfoI()
+    info.entityType = rstring("com.glencoesoftware.ngff:multiscales")
+    info.entityId = rlong(3)
+    info.lsid = rstring(path)
+    img.details.externalInfo = info
+    return img

--- a/src/omero_zarr/extinfo.py
+++ b/src/omero_zarr/extinfo.py
@@ -42,7 +42,7 @@ def get_extinfo(conn: BlitzGateway, image: ImageWrapper) -> ExternalInfoI:
             where e.id = :id
         """
         conn.SERVICE_OPTS.setOmeroGroup("-1")
-        extinfo = conn.getQueryService().findByQuery(query, params)
+        extinfo = conn.getQueryService().findByQuery(query, params, conn.SERVICE_OPTS)
         return extinfo
     return None
 
@@ -72,7 +72,7 @@ def _get_path(conn: BlitzGateway, image_id: int) -> str:
         where image.id = :id
     """
     conn.SERVICE_OPTS.setOmeroGroup("-1")
-    fs = conn.getQueryService().findByQuery(query, params)
+    fs = conn.getQueryService().findByQuery(query, params, conn.SERVICE_OPTS)
     path = fs._getUsedFiles()[0]._clientPath._val
     return path
 
@@ -241,8 +241,8 @@ def external_info_str(extinfo: ExternalInfoI) -> str:
     """
     if extinfo:
         return (
-            f"[entityType={_checkNone(extinfo.entityType)}\n"
-            f" entityId={_checkNone(extinfo.entityId)}\n"
-            f" lsid={_checkNone(extinfo.lsid)}]"
+            f"entityType={_checkNone(extinfo.entityType)}\n"
+            f"entityId={_checkNone(extinfo.entityId)}\n"
+            f"lsid={_checkNone(extinfo.lsid)}"
         )
     return "None"

--- a/src/omero_zarr/extinfo.py
+++ b/src/omero_zarr/extinfo.py
@@ -1,24 +1,16 @@
 import re
 
 from omero.gateway import BlitzGateway, BlitzObjectWrapper, ImageWrapper
-from omero.model import (
-    Dataset,
-    ExternalInfoI,
-    Image,
-    ImageI,
-    Plate,
-    Project,
-    Screen,
-)
+from omero.model import Dataset, ExternalInfoI, Image, ImageI, Plate, Project, Screen
 from omero.rtypes import rlong, rstring
 from omero_sys_ParametersI import ParametersI
-
 
 # Regex to match well positions (eg. A1)
 WELL_POS_RE = re.compile(r"(?P<row>\D+)(?P<col>\d+)")
 # Regex to match the metadata.xml (could be any xml under xyz.zarr/ directory,
 # not only xyz.zarr/OME/METADATA.ome.xml)
 METADATA_XML_RE = re.compile(r".+\.zarr\/(.+\.xml)")
+
 
 def get_extinfo(conn: BlitzGateway, image: ImageWrapper) -> ExternalInfoI:
     """
@@ -157,7 +149,7 @@ def set_external_info(
     idx: int,
     overwrite_path: str,
     entityType: str,
-    entityId: int
+    entityId: int,
 ) -> ImageI:
     """
     Set the external info for an OMERO image.
@@ -194,12 +186,10 @@ def set_external_info(
     else:
         if METADATA_XML_RE.match(img_path):
             metadata_xml = METADATA_XML_RE.match(img_path).group(1)
-            path = img_path.replace(metadata_xml,"")
+            path = img_path.replace(metadata_xml, "")
             path = f"/{path}"
         else:
-            raise ValueError(
-                f"Doesn't seem to be an ome.zarr: {img_path}"
-            )
+            raise ValueError(f"Doesn't seem to be an ome.zarr: {img_path}")
 
     if well:
         match = WELL_POS_RE.match(well)
@@ -212,7 +202,6 @@ def set_external_info(
     else:
         series = img.getSeries()._val
         path = f"{path}{series}"
-
 
     info = ExternalInfoI()
     info.entityType = rstring(entityType)

--- a/src/omero_zarr/extinfo.py
+++ b/src/omero_zarr/extinfo.py
@@ -179,10 +179,7 @@ def set_external_info(
 
     img_path = _get_path(conn, img.id)
     if overwrite_path:
-        if not overwrite_path.endswith("/"):
-            path = f"{overwrite_path}/"
-        else:
-            path = overwrite_path
+        path = overwrite_path
     else:
         if METADATA_XML_RE.match(img_path):
             metadata_xml = METADATA_XML_RE.match(img_path).group(1)
@@ -201,7 +198,8 @@ def set_external_info(
             raise ValueError(f"Couldn't parse well position: {well}")
     else:
         series = img.getSeries()._val
-        path = f"{path}{series}"
+        if not overwrite_path:
+            path = f"{path}{series}"
 
     info = ExternalInfoI()
     info.entityType = rstring(entityType)

--- a/src/omero_zarr/extinfo.py
+++ b/src/omero_zarr/extinfo.py
@@ -38,6 +38,7 @@ def get_extinfo(conn: BlitzGateway, image: ImageWrapper) -> ExternalInfoI:
             select e from ExternalInfo as e
             where e.id = :id
         """
+        conn.SERVICE_OPTS.setOmeroGroup("-1")
         extinfo = conn.getQueryService().findByQuery(query, params)
         return extinfo
     return None
@@ -66,6 +67,7 @@ def _get_path(conn: BlitzGateway, image_id: int) -> str:
         join fetch usedFile.originalFile as f
         join fetch f.hasher where image.id = :id
     """
+    conn.SERVICE_OPTS.setOmeroGroup("-1")
     fs = conn.getQueryService().findByQuery(query, params)
     res = fs._getUsedFiles()[0]._clientPath._val
     return res
@@ -93,7 +95,7 @@ def _lookup(conn: BlitzGateway, type: str, oid: int) -> BlitzObjectWrapper:
     return obj
 
 
-def get_images(conn: BlitzGateway, object) -> tuple[ImageWrapper, str | None, int | None]:
+def get_images(conn: BlitzGateway, object) -> tuple[ImageWrapper, str, int]:
     """
     Generator that yields images from any OMERO container object.
 
@@ -143,7 +145,7 @@ def get_images(conn: BlitzGateway, object) -> tuple[ImageWrapper, str | None, in
 
 
 def set_external_info(conn: BlitzGateway, img: ImageI, well: str, idx: int, 
-    lsid: str | None = None, entityType: str | None = None, entityId: int | None = None) -> ImageI:
+    lsid: str, entityType: str, entityId: int) -> ImageI:
     """
     Set the external info for an OMERO image.
 


### PR DESCRIPTION
This command will automatically set the ExternalInfo for ome.zarr images imported using the [omero-zarr-pixel-buffer](https://github.com/glencoesoftware/omero-zarr-pixel-buffer), if the `--set` option is specified. Default is to just print the ExternalInfo.

I takes the path from the Fileset "usedFiles", which is assumed to only have one entry `..../SOME.ome.zarr/OME/METADATA.ome.xml` and then set the ExternalInfo lsid to the full path of the multiscale 5d image; `..../SOME.ome.zarr/0` for an image `..../SOME.ome.zarr/A/1/1` etc. for plates.

**Limitations:** Only works for ome.zarr imported from the filesystem.

```
Get the ExternalInfo path of an ome.zarr image.

Use --set to set the external info path
or --reset in order to remove the ExternalInfo from the image.

Positional Arguments:
  object                   Object in Class:ID format

Optional Arguments:
  In addition to any higher level options

  -h, --help               show this help message and exit
  --set                    Set the ExternalInfo path
  --lsid LSID              Use a specific lsid (path) (default: Determine from clientPath) (only used in combination with --set)
  --entityType ENTITYTYPE  Use a specific entityType (default: com.glencoesoftware.ngff:multiscales) (only used in combination with --set)
  --entityId ENTITYID      Use a specific entityId (default: 3) (only used in combination with --set)
  --reset                  Removes the ExternalInfo
```
