### PR TITLE
Skip wells

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ To export Images or Plates via the OMERO API::
     $ omero zarr export Image:1 --metadata_only
     $ omero zarr export Plate:2 --metadata_only
 
+    # To export Key-Value pairs from Wells in a Plate as a CSV file,
+    $ omero zarr export_csv Plate:1 --skip_wells_map my_key:*
 
 NB: If the connection to OMERO is lost and the Image is partially exported,
 re-running the command will attempt to complete the export.

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,18 @@ To export Images or Plates via the OMERO API::
     # By default, a tile (chunk) size of 1024 is used. Specify values with
     $ omero zarr export Image:1 --tile_width 256 --tile_height 256
 
+    # To exclude Wells from a Plate export, based on Key-Value pairs
+    # (map annotations) use --skip_wells_map key:value. Supports wildcards.
+    $ omero zarr export Plate:1 --skip_wells_map my_key:my_value
+    $ omero zarr export Plate:1 --skip_wells_map my_key:my*
+    $ omero zarr export Plate:1 --skip_wells_map my_key:*value
+    $ omero zarr export Plate:1 --skip_wells_map my_key:*val*
+    $ omero zarr export Plate:1 --skip_wells_map my_key:*
+
+    # Use --metadata_only to export only metadata, no pixel data
+    $ omero zarr export Image:1 --metadata_only
+    $ omero zarr export Plate:2 --metadata_only
+
 
 NB: If the connection to OMERO is lost and the Image is partially exported,
 re-running the command will attempt to complete the export.

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -194,15 +194,6 @@ class ZarrControl(BaseControl):
             help=("Name of the array that will be stored. Ignored for --style=split"),
             default="0",
         )
-        polygons.add_argument(
-            "--name_by",
-            default="id",
-            choices=["id", "name"],
-            help=(
-                "How the existing Image or Plate zarr is named. Default 'id' is "
-                "[ID].ome.zarr. 'name' is [NAME].ome.zarr"
-            ),
-        )
 
         masks = parser.add(sub, self.masks, MASKS_HELP)
         masks.add_argument(
@@ -253,15 +244,6 @@ class ZarrControl(BaseControl):
                 "overlapping labels"
             ),
         )
-        masks.add_argument(
-            "--name_by",
-            default="id",
-            choices=["id", "name"],
-            help=(
-                "How the existing Image or Plate zarr is named. Default 'id' is "
-                "[ID].ome.zarr. 'name' is [NAME].ome.zarr"
-            ),
-        )
 
         export = parser.add(sub, self.export, EXPORT_HELP)
         export.add_argument(
@@ -297,23 +279,30 @@ class ZarrControl(BaseControl):
             help="Maximum number of workers (only for use with bioformats2raw)",
         )
         export.add_argument(
-            "--name_by",
-            default="id",
-            choices=["id", "name"],
-            help=(
-                "How to name the Image or Plate zarr. Default 'id' is [ID].ome.zarr. "
-                "'name' is [NAME].ome.zarr"
-            ),
-        )
-        export.add_argument(
             "object",
             type=ProxyStringType("Image"),
             help="The Image to export.",
         )
 
+        # Need same arguments for Images and Masks
         for subcommand in (polygons, masks, export):
             subcommand.add_argument(
                 "--output", type=str, default="", help="The output directory"
+            )
+            subcommand.add_argument(
+                "--skip_wells_map",
+                type=str,
+                help="For Plates, skip wells with MapAnnotation values"
+                "matching this key-value pair. e.g. 'MyKey:MyVal*'",
+            )
+            subcommand.add_argument(
+                "--name_by",
+                default="id",
+                choices=["id", "name"],
+                help=(
+                    "How to name the Image or Plate zarr. Default 'id' is "
+                    "[ID].ome.zarr. 'name' is [NAME].ome.zarr"
+                ),
             )
         for subcommand in (polygons, masks):
             subcommand.add_argument(

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -283,6 +283,11 @@ class ZarrControl(BaseControl):
             type=ProxyStringType("Image"),
             help="The Image to export.",
         )
+        export.add_argument(
+            "--metadata_only",
+            action="store_true",
+            help="Only write metadata, do not export pixel data",
+        )
 
         # Need same arguments for Images and Masks
         for subcommand in (polygons, masks, export):

--- a/src/omero_zarr/kvp_tables.py
+++ b/src/omero_zarr/kvp_tables.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2023 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import csv
+
+import omero.clients  # noqa
+
+from .util import get_map_anns, get_zarr_name, map_anns_match
+
+
+def plate_to_table(
+    plate: omero.gateway._PlateWrapper, args: argparse.Namespace
+) -> None:
+    """
+    Exports Well KVPs to a CSV table.
+    """
+    name = get_zarr_name(plate, args.output, args.name_by)
+    skip_wells_map = args.skip_wells_map
+
+    wells = list(plate.listChildren())
+    # sort by row then column...
+    wells = sorted(wells, key=lambda x: (x.row, x.column))
+    well_count = len(wells)
+
+    well_kvps_by_id = get_map_anns(wells)
+
+    if skip_wells_map:
+        # skip_wells_map is like MyKey:MyValue.
+        # Or wild-card MyKey:* or MyKey:Val*
+        wells = [
+            well
+            for well in wells
+            if not map_anns_match(well_kvps_by_id.get(well.id, {}), skip_wells_map)
+        ]
+        print(
+            f"Skipping {well_count - len(wells)} out of {well_count} wells"
+            f" with skip_wells_map: {skip_wells_map}"
+        )
+
+    keys_set = set()
+
+    for well in wells:
+        kvps = well_kvps_by_id.get(well.id, {})
+        for key in kvps.keys():
+            keys_set.add(key)
+
+    column_names = list(keys_set)
+    column_names = sorted(column_names)
+
+    print("column_names", column_names)
+
+    column_names = ["Well"] + column_names
+
+    # write csv file...
+    csv_name = name.replace(".ome.zarr", ".csv")
+    print(f"Writing CSV file: {csv_name}")
+    with open(csv_name, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(column_names)
+
+        for well in wells:
+            kvps = well_kvps_by_id.get(well.id, {})
+            row = [f"{well.id}"]
+            for key in column_names[1:]:
+                row.append(";".join(kvps.get(key, [])))
+            writer.writerow(row)

--- a/src/omero_zarr/kvp_tables.py
+++ b/src/omero_zarr/kvp_tables.py
@@ -65,18 +65,18 @@ def plate_to_table(
 
     print("column_names", column_names)
 
-    column_names = ["Well"] + column_names
+    plate_name = plate.getName()
 
     # write csv file...
     csv_name = name.replace(".ome.zarr", ".csv")
     print(f"Writing CSV file: {csv_name}")
     with open(csv_name, "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
-        writer.writerow(column_names)
+        writer.writerow(["Plate", "Well"] + column_names)
 
         for well in wells:
             kvps = well_kvps_by_id.get(well.id, {})
-            row = [f"{well.id}"]
-            for key in column_names[1:]:
+            row = [plate_name, f"{well.getWellPos()}"]
+            for key in column_names:
                 row.append(";".join(kvps.get(key, [])))
             writer.writerow(row)

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -316,7 +316,6 @@ class MaskSaver:
         }
         ignored_dimensions: Set[str] = set()
         print(f"Unique dimensions: {unique_dims}")
-        # We always ignore the C dimension
         if unique_dims["C"] == {None} or len(unique_dims["C"]) == 1:
             ignored_dimensions.add("C")
 
@@ -585,6 +584,7 @@ class MaskSaver:
                 if shape.fillColor:
                     fillColors[shape_value] = unwrap(shape.fillColor)
                 binim_yx, (t, c, z, y, x, h, w) = self.shape_to_binim_yx(shape)
+                # if z, c or t are None, we apply the mask to all Z, C or T indices
                 for i_t in self._get_indices(ignored_dimensions, "T", t, size_t):
                     for i_c in self._get_indices(ignored_dimensions, "C", c, size_c):
                         for i_z in self._get_indices(

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -311,12 +311,14 @@ class MaskSaver:
         # Figure out whether we can flatten some dimensions
         unique_dims: Dict[str, Set[int]] = {
             "T": {unwrap(mask.theT) for shapes in masks for mask in shapes},
+            "C": {unwrap(mask.theC) for shapes in masks for mask in shapes},
             "Z": {unwrap(mask.theZ) for shapes in masks for mask in shapes},
         }
         ignored_dimensions: Set[str] = set()
-        # We always ignore the C dimension
-        ignored_dimensions.add("C")
         print(f"Unique dimensions: {unique_dims}")
+        # We always ignore the C dimension
+        if unique_dims["C"] == {None} or len(unique_dims["C"]) == 1:
+            ignored_dimensions.add("C")
 
         for d in "TZ":
             if unique_dims[d] == {None}:

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -309,6 +309,7 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
     wells = list(plate.listChildren())
     # sort by row then column...
     wells = sorted(wells, key=lambda x: (x.row, x.column))
+    well_count = len(wells)
 
     if skip_wells_map:
         # skip_wells_map is like MyKey:MyValue.
@@ -319,6 +320,10 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
             for well in wells
             if not map_anns_match(well_kvps_by_id.get(well.id, {}), skip_wells_map)
         ]
+        print(
+            f"Skipping {well_count - len(wells)} out of {well_count} wells"
+            f" with skip_wells_map: {skip_wells_map}"
+        )
 
     for well in wells:
         row = plate.getRowLabels()[well.row]

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -336,7 +336,8 @@ def plate_to_zarr(plate: omero.gateway._PlateWrapper, args: argparse.Namespace) 
                 field_name = "%d" % field
                 count += 1
                 img = ws.getImage()
-                well_paths.append(f"{row}/{col}")
+                if f"{row}/{col}" not in well_paths:
+                    well_paths.append(f"{row}/{col}")
                 field_info = {"path": f"{field_name}"}
                 if ac:
                     field_info["acquisition"] = ac.id

--- a/test/integration/clitest/test_export.py
+++ b/test/integration/clitest/test_export.py
@@ -236,20 +236,21 @@ class TestRender(AbstractCLITest):
         img_id = images[0].id.val
         size_xy = 512
 
-        # Create a mask
+        # Create a mask for each channel
         from skimage.data import binary_blobs
 
-        blobs = binary_blobs(length=size_xy, volume_fraction=0.1, n_dim=2).astype(
-            "int8"
-        )
         red = [255, 0, 0, 255]
-        mask = mask_from_binary_image(blobs, rgba=red, z=0, c=0, t=0)
-
-        roi = RoiI()
-        roi.setImage(images[0])
-        roi.addShape(mask)
-        updateService = self.client.sf.getUpdateService()
-        updateService.saveAndReturnObject(roi)
+        green = [0, 255, 0, 255]
+        for ch, color in enumerate([red, green]):
+            blobs = binary_blobs(length=size_xy, volume_fraction=0.1, n_dim=2).astype(
+                "int8"
+            )
+            mask = mask_from_binary_image(blobs, rgba=color, z=0, c=ch, t=0)
+            roi = RoiI()
+            roi.setImage(images[0])
+            roi.addShape(mask)
+            updateService = self.client.sf.getUpdateService()
+            updateService.saveAndReturnObject(roi)
 
         print("tmp_path", tmp_path)
 
@@ -276,19 +277,22 @@ class TestRender(AbstractCLITest):
         all_lines = ", ".join(lines)
         assert "Exporting to" in all_lines
         assert "Finished" in all_lines
-        assert "Found 1 mask shapes in 1 ROIs" in all_lines
+        assert "Found 2 mask shapes in 2 ROIs" in all_lines
 
         labels_text = (tmp_path / zarr_name / "labels" / "0" / ".zattrs").read_text(
             encoding="utf-8"
         )
         labels_json = json.loads(labels_text)
-        assert labels_json["image-label"]["colors"] == [{"label-value": 1, "rgba": red}]
+        assert labels_json["image-label"]["colors"] == [
+            {"label-value": 1, "rgba": red},
+            {"label-value": 2, "rgba": green},
+        ]
 
         arr_text = (tmp_path / zarr_name / "labels" / "0" / "0" / ".zarray").read_text(
             encoding="utf-8"
         )
         arr_json = json.loads(arr_text)
-        assert arr_json["shape"] == [1, 512, 512]
+        assert arr_json["shape"] == [2, 512, 512]
 
     SKIP_WELLS_MAPS = {
         "": ["A1", "A2", "B1", "B2"],


### PR DESCRIPTION
This adds support for excluding Wells from Plate export, based on Key-Value pairs.

E.g. if we have `"my_key": "my_value"` on a Well, we can exclude that with an exact match or with wildcards:

```
$ omero zarr export Plate:1 --skip_wells_map my_key:my_value

$ omero zarr export Plate:1 --skip_wells_map my_key:my*
$ omero zarr export Plate:1 --skip_wells_map my_key:*value
$ omero zarr export Plate:1 --skip_wells_map my_key:*val*
$ omero zarr export Plate:1 --skip_wells_map my_key:*

# important to use same value if/when you export masks or polygons for the same Plate:

$ omero zarr masks Plate:1 --skip_wells_map my_key:my*
```

This PR also adds a `--metadata_only` option, which skips all the pixel data (no chunks) but still includes
array metadata `.zarray` etc. This allows a fast export of a Plate, e.g. to quickly test the `--skip_wells_map` above.

```
$ omero zarr export Plate:1 --metadata_only
```


cc @jrswedlow 
