### PR TITLE
Pin ome-zarr-py <0.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     author="The Open Microscopy Team",
     author_email="",
     python_requires=">=3",
-    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.5.0"],
+    install_requires=["omero-py>=5.6.0", "ome-zarr>=0.5.0,<0.12.0"],
     long_description=long_description,
     keywords=["OMERO.CLI", "plugin"],
     url="https://github.com/ome/omero-cli-zarr/",


### PR DESCRIPTION
When ome-zarr-py 0.12.0 is released, it will use zarr v3, which will be incompatible with this version of omero-cli-zarr (until either #172 is merged or we drop ome-zarr dependency).

So we need to make sure that this app doesn't install ome-zarr-py 0.12.0.