### PR TITLE
Only parse import uris if stated

### DIFF
--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -355,6 +355,13 @@ class ZarrControl(BaseControl):
             "--nosignrequest", action="store_true", help="Indicate to sign anonymously"
         )
         import_cmd.add_argument(
+            "--parseuri",
+            action="store_true",
+            help="Try to parse the URI to extract endpoint, bucket and path "
+            "in order to  create a S3 URI (e.g. from an HTTP URI) "
+            "(default: Just use the URI as-is)",
+        )
+        import_cmd.add_argument(
             "--target",
             type=str,
             help=(
@@ -426,6 +433,7 @@ class ZarrControl(BaseControl):
             uri=args.uri,
             endpoint=args.endpoint,
             nosignrequest=args.nosignrequest,
+            parseuri=args.parseuri,
             name=args.name,
             target=args.target,
             target_by_name=args.target_by_name,

--- a/src/omero_zarr/cli.py
+++ b/src/omero_zarr/cli.py
@@ -357,9 +357,12 @@ class ZarrControl(BaseControl):
         import_cmd.add_argument(
             "--parseuri",
             action="store_true",
-            help="Try to parse the URI to extract endpoint, bucket and path "
-            "in order to  create a S3 URI (e.g. from an HTTP URI) "
-            "(default: Just use the URI as-is)",
+            help=(
+                "Try to parse the URI to extract endpoint, bucket and path "
+                "in order to create a S3 URI (e.g. from an HTTP URI), needed for "
+                "omero-zarr-pixel-buffer versions < 0.7 which didn't support http "
+                "(default: Just use the URI as-is)"
+            ),
         )
         import_cmd.add_argument(
             "--target",

--- a/src/omero_zarr/zarr_import.py
+++ b/src/omero_zarr/zarr_import.py
@@ -562,27 +562,33 @@ def set_external_info(
     uri = kwargs.get("uri", "")
     endpoint = kwargs.get("endpoint", "")
     nosignrequest = kwargs.get("nosignrequest", False)
+    parseuri = kwargs.get("parseuri", False)
 
-    if image_path is not None:
-        uri = uri.rstrip("/") + "/" + image_path
-    parsed_uri = urlsplit(uri)
-    scheme = f"{parsed_uri.scheme}"
+    if parseuri:
+        if image_path is not None:
+            uri = uri.rstrip("/") + "/" + image_path
+        parsed_uri = urlsplit(uri)
+        scheme = f"{parsed_uri.scheme}"
 
-    if "http" in scheme:
-        endpoint = "https://" + f"{parsed_uri.netloc}"
-        nosignrequest = True
-        path = f"{parsed_uri.path}"
-        if path.startswith("/"):
-            path = path[1:]
-        # omero-zarr-pixel-buffer s3 - need to remove /
-        if path.endswith("/"):
-            path = path[:-1]
-        uri = "s3://" + path
+        if "http" in scheme:
+            endpoint = "https://" + f"{parsed_uri.netloc}"
+            nosignrequest = True
+            path = f"{parsed_uri.path}"
+            if path.startswith("/"):
+                path = path[1:]
+            # omero-zarr-pixel-buffer s3 - need to remove trailing slash
+            if path.endswith("/"):
+                path = path[:-1]
+            uri = "s3://" + path
 
-    if not uri.startswith("/"):
-        uri = format_s3_uri(uri, endpoint)
-    if nosignrequest:
-        uri = uri + "?anonymous=true"
+        if not uri.startswith("/"):
+            uri = format_s3_uri(uri, endpoint)
+        if nosignrequest:
+            uri = uri + "?anonymous=true"
+    else:
+        # omero-zarr-pixel-buffer s3 - need to remove trailing slash
+        uri = uri.rstrip("/")
+        
     setattr(extinfo, "lsid", rstring(uri))
     print("lsid:", uri)
     image.details.externalInfo = extinfo

--- a/src/omero_zarr/zarr_import.py
+++ b/src/omero_zarr/zarr_import.py
@@ -585,7 +585,7 @@ def set_external_info(
             uri = format_s3_uri(uri, endpoint)
         if nosignrequest:
             uri = uri + "?anonymous=true"
-        
+
     setattr(extinfo, "lsid", rstring(uri))
     print("lsid:", uri)
     image.details.externalInfo = extinfo

--- a/src/omero_zarr/zarr_import.py
+++ b/src/omero_zarr/zarr_import.py
@@ -564,30 +564,27 @@ def set_external_info(
     nosignrequest = kwargs.get("nosignrequest", False)
     parseuri = kwargs.get("parseuri", False)
 
+    if image_path is not None:
+        uri = uri.rstrip("/") + "/" + image_path
+
+    # omero-zarr-pixel-buffer s3 - need to remove potential trailing slash
+    uri = uri.rstrip("/")
+
     if parseuri:
-        if image_path is not None:
-            uri = uri.rstrip("/") + "/" + image_path
         parsed_uri = urlsplit(uri)
         scheme = f"{parsed_uri.scheme}"
-
         if "http" in scheme:
             endpoint = "https://" + f"{parsed_uri.netloc}"
             nosignrequest = True
             path = f"{parsed_uri.path}"
             if path.startswith("/"):
                 path = path[1:]
-            # omero-zarr-pixel-buffer s3 - need to remove trailing slash
-            if path.endswith("/"):
-                path = path[:-1]
             uri = "s3://" + path
 
         if not uri.startswith("/"):
             uri = format_s3_uri(uri, endpoint)
         if nosignrequest:
             uri = uri + "?anonymous=true"
-    else:
-        # omero-zarr-pixel-buffer s3 - need to remove trailing slash
-        uri = uri.rstrip("/")
         
     setattr(extinfo, "lsid", rstring(uri))
     print("lsid:", uri)

--- a/src/omero_zarr/zarr_import.py
+++ b/src/omero_zarr/zarr_import.py
@@ -429,26 +429,28 @@ def set_external_info(
     uri = kwargs.get("uri", "")
     endpoint = kwargs.get("endpoint", "")
     nosignrequest = kwargs.get("nosignrequest", False)
+    parseuri = kwargs.get("parseuri", False)
 
-    if image_path is not None:
-        uri = uri.rstrip("/") + "/" + image_path
-    parsed_uri = urlsplit(uri)
-    scheme = f"{parsed_uri.scheme}"
+    if parseuri:
+        if image_path is not None:
+            uri = uri.rstrip("/") + "/" + image_path
+        parsed_uri = urlsplit(uri)
+        scheme = f"{parsed_uri.scheme}"
 
-    if "http" in scheme:
-        endpoint = "https://" + f"{parsed_uri.netloc}"
-        nosignrequest = True
-        path = f"{parsed_uri.path}"
-        if path.startswith("/"):
-            path = path[1:]
-        uri = "s3://" + path
+        if "http" in scheme:
+            endpoint = "https://" + f"{parsed_uri.netloc}"
+            nosignrequest = True
+            path = f"{parsed_uri.path}"
+            if path.startswith("/"):
+                path = path[1:]
+            uri = "s3://" + path
 
-    if not uri.startswith("/"):
-        uri = format_s3_uri(uri, endpoint)
-    if nosignrequest:
-        if not uri.endswith("/"):
-            uri = uri + "/"
-        uri = uri + "?anonymous=true"
+        if not uri.startswith("/"):
+            uri = format_s3_uri(uri, endpoint)
+        if nosignrequest:
+            if not uri.endswith("/"):
+                uri = uri + "/"
+            uri = uri + "?anonymous=true"
     setattr(extinfo, "lsid", rstring(uri))
     print("lsid:", uri)
     image.details.externalInfo = extinfo


### PR DESCRIPTION
With https://github.com/ome/omero-zarr-pixel-buffer/pull/13 it won't be necessary any longer to translate http into s3 URLs. The option is still available but only when explicetely stated (via `--parseuri` flag).
