### PR TITLE
Storage options only if needed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--target-version=py36]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.16.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args:

--- a/src/omero_zarr/masks.py
+++ b/src/omero_zarr/masks.py
@@ -117,6 +117,13 @@ def plate_shapes_to_zarr(
 
 
 def get_label_map(masks: Dict, label_map_arg: str) -> Dict:
+    """
+    Generate a label map from the given masks and label map argument.
+
+    @param masks: Dictionary of masks
+    @param label_map_arg: Path to the label map file
+    @return: Dictionary {name: List[masks]} mapping label names to masks
+    """
     label_map = defaultdict(list)
     roi_map = {}
     for roi_id, roi in masks.items():
@@ -135,6 +142,9 @@ def get_label_map(masks: Dict, label_map_arg: str) -> Dict:
 
 
 def get_shapes(image: omero.gateway.ImageWrapper, shape_types: List[str]) -> Dict:
+    """
+    Returns dict of {roi_id: [shapes]} for "Mask" or "Polygon" shapes on the Image
+    """
     shape_classes = []
     for klass in shape_types:
         if klass in SHAPE_TYPES:

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -252,9 +252,7 @@ def downsample_pyramid_on_disk(
                 "name": "v2",
                 "separator": "/",
             }
-            zarr_array_kwargs["compressor"] = Blosc(
-                cname="zstd", clevel=5, shuffle=Blosc.SHUFFLE
-            )
+            zarr_array_kwargs["zarr_format"] = 2
         else:
             zarr_array_kwargs["chunk_key_encoding"] = fmt.chunk_key_encoding
             if dim_names is not None:

--- a/src/omero_zarr/raw_pixels.py
+++ b/src/omero_zarr/raw_pixels.py
@@ -265,7 +265,7 @@ def downsample_pyramid_on_disk(
             arr=output,
             url=parent.store_path,
             component=path,
-            zarr_array_kwargs=zarr_array_kwargs,
+            **zarr_array_kwargs,
         )
 
     return paths

--- a/src/omero_zarr/zarr_import.py
+++ b/src/omero_zarr/zarr_import.py
@@ -551,7 +551,8 @@ def import_zarr(
         if endpoint:
             storage_options["client_kwargs"] = {"endpoint_url": endpoint}
 
-        args["storage_options"] = storage_options
+        if len(storage_options) > 0:
+            args["storage_options"] = storage_options
 
     root_group = open_group(uri, mode="r", **args)
     store = root_group.store

--- a/test/integration/clitest/test_export.py
+++ b/test/integration/clitest/test_export.py
@@ -304,7 +304,7 @@ class TestExport(AbstractCLITest):
             labels_json = labels_json.get("attributes", {}).get("ome")
         assert labels_json["image-label"]["colors"] == [{"label-value": 1, "rgba": red}]
 
-        arr_text = (tmp_path / zarr_name / "labels" / "0" / "0" / arr_name).read_text(
+        arr_text = (tmp_path / zarr_name / "labels" / "0" / "s0" / arr_name).read_text(
             encoding="utf-8"
         )
         arr_json = json.loads(arr_text)


### PR DESCRIPTION
Fixes this error, seen with `zarr==3.1.5`:

```
$ omero zarr import 6001240.ome.zarr --target 1802
Using session for user-3@10.0.48.5:4064. Idle timeout: 10 min. Current group: Read Annotate
Storage options: {}
Traceback (most recent call last):
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/bin/omero", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/omero/main.py", line 125, in main
    rv = omero.cli.argv()
         ^^^^^^^^^^^^^^^^
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/omero/cli.py", line 1771, in argv
    cli.invoke(args[1:])
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/omero/cli.py", line 1208, in invoke
    stop = self.onecmd(line, previous_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/omero/cli.py", line 1285, in onecmd
    self.execute(line, previous_args)
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/omero/cli.py", line 1367, in execute
    args.func(args)
  File "/Users/wmoore/Desktop/ZARR/omero-cli-zarr/src/omero_zarr/cli.py", line 133, in _wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/wmoore/Desktop/ZARR/omero-cli-zarr/src/omero_zarr/cli.py", line 424, in import_cmd
    import_zarr(
  File "/Users/wmoore/Desktop/ZARR/omero-cli-zarr/src/omero_zarr/zarr_import.py", line 558, in import_zarr
    root_group = open_group(uri, mode="r", **args)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/zarr/api/synchronous.py", line 549, in open_group
    sync(
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/zarr/core/sync.py", line 159, in sync
    raise return_result
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/zarr/core/sync.py", line 119, in _runner
    return await coro
           ^^^^^^^^^^
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/zarr/api/asynchronous.py", line 860, in open_group
    store_path = await make_store_path(store, mode=mode, storage_options=storage_options, path=path)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/zarr/storage/_common.py", line 422, in make_store_path
    store = await make_store(store_like, mode=mode, storage_options=storage_options)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb_zarrv3/lib/python3.12/site-packages/zarr/storage/_common.py", line 312, in make_store
    raise TypeError(
TypeError: 'storage_options' was provided but unused. 'storage_options' is only used when the store is passed as a FSSpec URI string.
```

To test (need a python env with omero-py):

 - `$ pip install -e .` (from this branch, or checkout this branch if already installed from this repo)
 - `$ pip install -U zarr` (in case you have older zarr already installed)
 - `$ omero zarr import https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr --target DATASET_ID` (e.g. use image from NGFF converter)
 - `$ omero zarr export Image:123`
 
