### PR TITLE
Fix pragma

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,9 +34,6 @@ repos:
       - id: check-json
         files: \.(json)$
       - id: check-yaml
-      - id: fix-encoding-pragma
-        args:
-          - --remove
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-symlinks


### PR DESCRIPTION
Fixing the pre-commit hooks failure in https://github.com/ome/omero-cli-zarr/actions/runs/32071007727/job/95514011239

The error in GHA says

```
fix-encoding-pragma` has been removed -- use `pyupgrade` from https://github.com/asottile/pyupgrade
```

Removing the ``fix-enconding-pragme`` -> the ``pyupgrade`` is already included in the same file, just one paragraph above. 

cc @will-moore @jburel 